### PR TITLE
Name changed a character and also deleted/subsituted honorifics

### DIFF
--- a/www/data/Actors.json
+++ b/www/data/Actors.json
@@ -97,7 +97,7 @@
     "traits": [],
     "initialLevel": 1,
     "maxLevel": 99,
-    "name": "Phils",
+    "name": "Philis",
     "nickname": "",
     "note": "",
     "profile": ""

--- a/www/data/CommonEvents.json
+++ b/www/data/CommonEvents.json
@@ -27361,7 +27361,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Thief C>\"So this is the famous Holy Knight-sama. But to be\naffected by that drug like this, it means they had\nsome potential from the start, right? Being a\ndirty pervert is one thing, but this is going too\nfar.\""
+          "\\N<Thief C>\"So this is the famous Holy Knight. But to be\naffected by that drug like this, it means they had\nsome potential from the start, right? Being a\ndirty pervert is one thing, but this is going too\nfar.\""
         ]
       },
       { "code": 0, "indent": 0, "parameters": [""] },
@@ -34284,7 +34284,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Young Monk>\\CE[79]\\CE[78]\\CE[83]If I were to cross paths with\nSister Phils, my hands would throb with the desire\nto grope her voluptuous body, and whenever I see a\nbeautiful woman in town, my mind starts\nfantasizing about playing with her."
+          "\\N<Young Monk>\\CE[79]\\CE[78]\\CE[83]If I were to cross paths with\nSister Philis, my hands would throb with the desire\nto grope her voluptuous body, and whenever I see a\nbeautiful woman in town, my mind starts\nfantasizing about playing with her."
         ]
       },
       { "code": 0, "indent": 0, "parameters": [""] },
@@ -37589,7 +37589,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Neighbor: \"Me, Meryl-chan... your love juices are\ndripping...!\""
+          "Neighbor: \"Me, Meryl... your love juices are\ndripping...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -37643,7 +37643,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Neighbor: \"I, I understand, Meryl-chan... I'll...\nI'll fuck you with this dick until you're\nsatisfied!!\""
+          "Neighbor: \"I, I understand, Meryl... I'll...\nI'll fuck you with this dick until you're\nsatisfied!!\""
         ]
       },
       { "code": 108, "indent": 0, "parameters": ["ピストン２"] },
@@ -37806,7 +37806,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Neighbor: \"Here I go Meryl-chan! I'm going to keep\nfucking you...!!\""
+          "Neighbor: \"Here I go Meryl! I'm going to keep\nfucking you...!!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -37907,7 +37907,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Neighbor: \"Aaaaa─────Meryl-chan Meryl-chan♥♥♥ I'm\ngoing to cum again inside Meryl's pussy───────!!\""
+          "Neighbor: \"Aaaaa─────Meryl Meryl♥♥♥ I'm\ngoing to cum again inside Meryl's pussy───────!!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -38103,7 +38103,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<The man who was the neighbor at the inn> \"I'm\nsorry, Meryl-chan... But to carve myself into your\nbody, it has to hurt a little.\""
+          "<The man who was the neighbor at the inn> \"I'm\nsorry, Meryl... But to carve myself into your\nbody, it has to hurt a little.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -38125,7 +38125,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<The man who was the neighbor at the inn> \"Hehe,\nMeryl-chan, you're usually the one doing the\nattacking, but,\""
+          "<The man who was the neighbor at the inn> \"Hehe,\nMeryl, you're usually the one doing the\nattacking, but,\""
         ]
       },
       {
@@ -38380,7 +38380,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<The man who was the neighbor at the inn> \"Meryl-\nchan Meryl-chan Meryl-chan Meryl-chan♥♥ Ahhh～～\nYour pussy♥ I'll fuck it until it's a sloppy mess\""
+          "<The man who was the neighbor at the inn> \"Meryl\n Meryl Meryl Meryl♥♥ Ahhh～～\nYour pussy♥ I'll fuck it until it's a sloppy mess\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -43247,7 +43247,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<The man who was peeping>\"───In that sense, you seem quite stern, Knight-\nsan, but you're actually quite lewd, aren't you?\nComing to watch someone's sex like this, you're\nquite the pervert.\""
+          "\\N<The man who was peeping>\"───In that sense, you seem quite stern, Miss\nKnight, but you're actually quite lewd, aren't you?\nComing to watch someone's sex like this, you're\nquite the pervert.\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [78, 78, 0, 0, 0] },
@@ -43385,7 +43385,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[79]\\N<The man who was peeping>\"There's a hole in the door of the room that's\nperfect for peeping, so Knight-san, please watch\nfrom there. Of course, feel free to do as you like\nwithout worrying about us♥\""
+          "\\CE[79]\\N<The man who was peeping>\"There's a hole in the door of the room that's\nperfect for peeping, so Miss Knight, please watch\nfrom there. Of course, feel free to do as you like\nwithout worrying about us♥\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -47896,7 +47896,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<A brown-haired man who looks like a flirt>\"───Hey? Isn't that Rain-chan?\""
+          "\\N<A brown-haired man who looks like a flirt>\"───Hey? Isn't that Rain?\""
         ]
       },
       {
@@ -48020,7 +48020,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<A brown-haired man who looks like a flirt>\"Ah, that's because we've 'gotten close' before.\nRight, Rain-chan♥?\""
+          "\\N<A brown-haired man who looks like a flirt>\"Ah, that's because we've 'gotten close' before.\nRight, Rain♥?\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [85, 85, 0, 4, "\"003\""] },
@@ -48068,7 +48068,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<A brown-haired man who looks like a flirt>\"Well, you see, Rain-chan was peeping on you while\nyou were doing it at the rocky area. I found her\nand, one thing led to another, she gave me a\nblowjob.\""
+          "\\N<A brown-haired man who looks like a flirt>\"Well, you see, Rain was peeping on you while\nyou were doing it at the rocky area. I found her\nand, one thing led to another, she gave me a\nblowjob.\""
         ]
       },
       { "code": 213, "indent": 0, "parameters": [-1, 14, false] },
@@ -48186,7 +48186,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned man>\"No matter how cute she is, isn't that kind of\nbad? Rain-chan, you don't feel bad about having\nyour sex watched?\""
+          "\\N<Sun-tanned man>\"No matter how cute she is, isn't that kind of\nbad? Rain, you don't feel bad about having\nyour sex watched?\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [87, 87, 0, 4, "\"009\""] },
@@ -48203,7 +48203,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<A brown-haired man who looks like a flirt>\"Rain-chan was totally captivated. She didn't even\nnotice me approaching until I spoke to her.\""
+          "\\N<A brown-haired man who looks like a flirt>\"Rain was totally captivated. She didn't even\nnotice me approaching until I spoke to her.\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [87, 87, 0, 4, "\"016\""] },
@@ -48228,7 +48228,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[79]\\N<Sun-tanned man>\"But wait, then you did it with this guy\nafterwards? Does that mean watching me got Rain-\nchan all hot and bothered?\""
+          "\\CE[79]\\N<Sun-tanned man>\"But wait, then you did it with this guy\nafterwards? Does that mean watching me got Rain\n all hot and bothered?\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [85, 85, 0, 4, "\"003\""] },
@@ -48262,7 +48262,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[79]\\CE[78]\\N<Sun-tanned man>\"So that's how it is. Just say it then～♪ In that\ncase, there's a way to satisfy both Rain-chan's\npunishment and desire at the same time...♥\""
+          "\\CE[79]\\CE[78]\\N<Sun-tanned man>\"So that's how it is. Just say it then～♪ In that\ncase, there's a way to satisfy both Rain's\npunishment and desire at the same time...♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -48544,7 +48544,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned Man>\"Ohhh～～～───♥ Ahh, oh♥ Damn, Rain-chan's pussy\nfeels so good♥\""
+          "\\N<Sun-tanned Man>\"Ohhh～～～───♥ Ahh, oh♥ Damn, Rain's pussy\nfeels so good♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -48552,7 +48552,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<A flirtatious-looking man with brown hair>\"Right? Rain-chan's body is so tight, her pussy's\ngrip is amazing too～♪\""
+          "\\N<A flirtatious-looking man with brown hair>\"Right? Rain's body is so tight, her pussy's\ngrip is amazing too～♪\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -48577,7 +48577,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned Man>\"Ah, this is bad♥ And look at Rain-chan, she's so\nwet. She must be turned on by the outdoor sex♪\""
+          "\\N<Sun-tanned Man>\"Ah, this is bad♥ And look at Rain, she's so\nwet. She must be turned on by the outdoor sex♪\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -49089,7 +49089,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned Man>\"─────Everyone's staring hard. They're watching me\nand Rain-chan getting it on♥\""
+          "\\N<Sun-tanned Man>\"─────Everyone's staring hard. They're watching me\nand Rain getting it on♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -49463,7 +49463,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned man>\"Nah, that felt freaking amazing♥ Your pussy is\nthe best, Rain-chan♪\""
+          "\\N<Sun-tanned man>\"Nah, that felt freaking amazing♥ Your pussy is\nthe best, Rain♪\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [78, 78, 0, 0, 0] },
@@ -49481,7 +49481,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Sun-tanned man>\"If you've learned your lesson about peeping,\ndon't do it again♪ But if you ever want to have\nsex outdoors, just call me. I'm always up for it\nwith you, Rain-chan♥\""
+          "\\N<Sun-tanned man>\"If you've learned your lesson about peeping,\ndon't do it again♪ But if you ever want to have\nsex outdoors, just call me. I'm always up for it\nwith you, Rain♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -51070,7 +51070,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\N[4]> \"Rain-san!! I heard something like a\nscream, are you okay?!\""
+          "<\\N[4]> \"Rain!! I heard something like a\nscream, are you okay?!\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -54851,7 +54851,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[79]\\CE[94]\\OC[31]\\N<Rain>\"By discarding unnecessary things, I've become\ntrue to myself. \\N[7]-sama helped me remove the\nshackles on my heart that were holding me back.\""
+          "\\CE[79]\\CE[94]\\OC[31]\\N<Rain>\"By discarding unnecessary things, I've become\ntrue to myself. Lord \\N[7] helped me remove the\nshackles on my heart that were holding me back.\""
         ]
       },
       {
@@ -54978,7 +54978,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[337]\\OC[5]\\N<\\N[7]>\"My, my. It seems your former lover still can't\nbelieve it, can he? About the current Rain-san.\""
+          "\\CE[337]\\OC[5]\\N<\\N[7]>\"My, my. It seems your former lover still can't\nbelieve it, can he? About the current Rain.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -55005,7 +55005,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\CE[94]\\CE[95]\\OC[31]\\N<Rain>\"It seems so... \\N[7]-sama, may I ask for your\nassistance...?\""
+          "\\CE[94]\\CE[95]\\OC[31]\\N<Rain>\"It seems so... Lord \\N[7], may I ask for your\nassistance...?\""
         ]
       },
       {
@@ -55375,7 +55375,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<The soldier who came running>\"Sorry, I'm off to see Rain-san now♥\""
+          "\\N<The soldier who came running>\"Sorry, I'm off to see Rain now♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -55610,7 +55610,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Soldier A>\"But seriously───── Rain-san has changed, huh?\nNever imagined she'd do something like that.\""
+          "\\N<Soldier A>\"But seriously───── Rain has changed, huh?\nNever imagined she'd do something like that.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -55626,7 +55626,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Soldier A>\"Ah, true. Haven't seen the Paladin Commander\naround lately... But even so, was Rain-san ever\nthat kind of character?\""
+          "\\N<Soldier A>\"Ah, true. Haven't seen the Paladin Commander\naround lately... But even so, was Rain ever\nthat kind of character?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -56987,7 +56987,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"Whoa, oh...what an exciting sight...! I\ncan clearly see myself and Rain-chan fully joined\ntogether.\""
+          "<\\V[631]> \"Whoa, oh...what an exciting sight...! I\ncan clearly see myself and Rain fully joined\ntogether.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -57011,7 +57011,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"My pre-cum and Rain-chan's love juices\nare smeared all over, making both pussy and dick\nall squishy... It's incredibly arousing...\""
+          "<\\V[631]> \"My pre-cum and Rain's love juices\nare smeared all over, making both pussy and dick\nall squishy... It's incredibly arousing...\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -57154,7 +57154,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"Guh, ugh────it's so intense...and Rain-\nchan, you're squeezing your pussy too tight...! If\nyou keep doing that───────\""
+          "<\\V[631]> \"Guh, ugh────it's so intense...and Rain\n, you're squeezing your pussy too tight...! If\nyou keep doing that───────\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -57169,14 +57169,14 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["<\\V[631]> \"Agguh─────nuuahh...! Ra, Rain-chan!\""]
+        "parameters": ["<\\V[631]> \"Agguh─────nuuahh...! Ra, Rain!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"I can't take it anymore! Ahhhhh! Rain-\nchan! I'm going to cum inside!!\""
+          "<\\V[631]> \"I can't take it anymore! Ahhhhh! Rain\n! I'm going to cum inside!!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -58314,7 +58314,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"───── Buhfuuh, Rain-chan's tight pussy,\nit's the best!\""
+          "<\\V[631]> \"───── Buhfuuh, Rain's tight pussy,\nit's the best!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -58374,7 +58374,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["<\\V[631]> \"Ahh, Rain-chan... Ahh, Rain-channn!!\""]
+        "parameters": ["<\\V[631]> \"Ahh, Rain... Ahh, Rainnn!!\""]
       },
       { "code": 122, "indent": 0, "parameters": [499, 499, 0, 0, 1] },
       {
@@ -58420,7 +58420,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"Rain-chan, I'm about to cum! I'm going\nto release it inside! Is that okay!?\""
+          "<\\V[631]> \"Rain, I'm about to cum! I'm going\nto release it inside! Is that okay!?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -58435,7 +58435,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"Ahh─── I'm going to pour baby juice\ninto Rain-chan's tender pussy!!\""
+          "<\\V[631]> \"Ahh─── I'm going to pour baby juice\ninto Rain's tender pussy!!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -58443,7 +58443,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<\\V[631]> \"Nuooh ahhh! I'm cumming, I'm cumming!\nAhhh impregnate Rain-chan!!!\""
+          "<\\V[631]> \"Nuooh ahhh! I'm cumming, I'm cumming!\nAhhh impregnate Rain!!!\""
         ]
       },
       { "code": 246, "indent": 0, "parameters": [1] },
@@ -62133,7 +62133,7 @@
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
-      { "code": 401, "indent": 0, "parameters": ["\\OC[30]<Phils> \"Kyaa!\""] },
+      { "code": 401, "indent": 0, "parameters": ["\\OC[30]<Philis> \"Kyaa!\""] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
@@ -62144,14 +62144,14 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Th-this is... that...─────\""]
+        "parameters": ["\\OC[30]<Philis> \"Th-this is... that...─────\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man> \"Could it be, Phils-chan, it's\nyour first time seeing a dick?\""
+          "<Controlled Man> \"Could it be, Philis, it's\nyour first time seeing a dick?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62159,7 +62159,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"...Yes... I'm embarrassed to\nsay...\""
+          "\\OC[30]<Philis> \"...Yes... I'm embarrassed to\nsay...\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62177,7 +62177,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"I do have the knowledge, at\nleast...\""
+          "\\OC[30]<Philis> \"I do have the knowledge, at\nleast...\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62186,7 +62186,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"O-Okay...\""]
+        "parameters": ["\\OC[30]<Philis> \"O-Okay...\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       {
@@ -62225,7 +62225,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Is this how it's supposed to\nbe...?\""
+          "\\OC[30]<Philis> \"Is this how it's supposed to\nbe...?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62241,7 +62241,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man> \"Huu... huu... that's good,\nPhils-chan, it feels good...\""
+          "<Controlled Man> \"Huu... huu... that's good,\nPhilis, it feels good...\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62250,7 +62250,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> (Ah, it's hot... I didn't know it\nwas this hot...)"
+          "\\OC[30]<Philis> (Ah, it's hot... I didn't know it\nwas this hot...)"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62264,7 +62264,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(Plus, there's this unique smell...\nIt's a scent I'm not very familiar with...)"
+          "\\OC[30]<Philis>(Plus, there's this unique smell...\nIt's a scent I'm not very familiar with...)"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62272,7 +62272,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(When I smell this scent... somehow\nmy crotch feels strange...)"
+          "\\OC[30]<Philis>(When I smell this scent... somehow\nmy crotch feels strange...)"
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62287,14 +62287,14 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man>\"Phils-chan... can you grip it\ntighter and move your hand more intensely?\""
+          "<Controlled Man>\"Philis... can you grip it\ntighter and move your hand more intensely?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Yes... of course...\""]
+        "parameters": ["\\OC[30]<Philis>\"Yes... of course...\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       {
@@ -62357,7 +62357,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Phils>\"Gaman juice... is that what this is?... I\nnever knew...\""
+          "<Philis>\"Gaman juice... is that what this is?... I\nnever knew...\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62365,7 +62365,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man>\"You know, Phils-chan, when you\nfeel good, something similar comes out too.\""
+          "<Controlled Man>\"You know, Philis, when you\nfeel good, something similar comes out too.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62378,21 +62378,21 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Ah...! So that's... how it is...\""]
+        "parameters": ["\\OC[30]<Philis>\"Ah...! So that's... how it is...\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man>\"...Hey Phils-chan, you're so\nfascinated by my dick that your hands have stopped\nmoving.\""
+          "<Controlled Man>\"...Hey Philis, you're so\nfascinated by my dick that your hands have stopped\nmoving.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Ah... I'm sorry!\""]
+        "parameters": ["\\OC[30]<Philis>\"Ah... I'm sorry!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -62406,7 +62406,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Fe...Eh!? L-lick it...!?\""]
+        "parameters": ["\\OC[30]<Philis>\"Fe...Eh!? L-lick it...!?\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -62420,7 +62420,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Yes...!\""]
+        "parameters": ["\\OC[30]<Philis>\"Yes...!\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       {
@@ -62453,14 +62453,14 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Fu...haa... haa...─────\""]
+        "parameters": ["\\OC[30]<Philis>\"Fu...haa... haa...─────\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man>\"Haa~~... Ahh, that feels good!\nPhils-chan, it feels so good!\""
+          "<Controlled Man>\"Haa~~... Ahh, that feels good!\nPhilis, it feels so good!\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62468,14 +62468,14 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>(This is... the taste of a dick...)"]
+        "parameters": ["\\OC[30]<Philis>(This is... the taste of a dick...)"]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(It's a bit salty... but smooth...\nand maybe even tasty...?)"
+          "\\OC[30]<Philis>(It's a bit salty... but smooth...\nand maybe even tasty...?)"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62504,11 +62504,11 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Controlled Man>\"Ahh, this is bad, this is bad!\nPhils-chan, stop! I'm gonna cum!\""
+          "<Controlled Man>\"Ahh, this is bad, this is bad!\nPhilis, stop! I'm gonna cum!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
-      { "code": 401, "indent": 0, "parameters": ["\\OC[30]<Phils>\"Eh...?\""] },
+      { "code": 401, "indent": 0, "parameters": ["\\OC[30]<Philis>\"Eh...?\""] },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 246, "indent": 0, "parameters": [1] },
       { "code": 356, "indent": 0, "parameters": ["SV_STOP_VOICE"] },
@@ -62548,7 +62548,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Ah... pfft...!\""]
+        "parameters": ["\\OC[30]<Philis>\"Ah... pfft...!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 2, 2] },
       {
@@ -62592,7 +62592,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Haa, haa... haa... this is...\""]
+        "parameters": ["\\OC[30]<Philis>\"Haa, haa... haa... this is...\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -62605,7 +62605,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>\"Haa... fuu... So, does that mean it\nworked properly...?\""
+          "\\OC[30]<Philis>\"Haa... fuu... So, does that mean it\nworked properly...?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62619,7 +62619,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>\"If that's the case... thank\ngoodness...\""
+          "\\OC[30]<Philis>\"If that's the case... thank\ngoodness...\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62628,7 +62628,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(The semen... it's stickier than\nvaginal fluids... and has such a strong smell...)"
+          "\\OC[30]<Philis>(The semen... it's stickier than\nvaginal fluids... and has such a strong smell...)"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62636,7 +62636,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(Why is it... even though I'm so\ndirty, my heart is racing...?)"
+          "\\OC[30]<Philis>(Why is it... even though I'm so\ndirty, my heart is racing...?)"
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62689,21 +62689,21 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Ah...─────\""]
+        "parameters": ["\\OC[30]<Philis> \"Ah...─────\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Manipulated Man> \"Phils-chan's breasts are\namazing... they're so exciting...!\""
+          "<Manipulated Man> \"Philis's breasts are\namazing... they're so exciting...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"It's... embarrassing...\""]
+        "parameters": ["\\OC[30]<Philis> \"It's... embarrassing...\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -62725,7 +62725,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Yes... I understand...\""]
+        "parameters": ["\\OC[30]<Philis> \"Yes... I understand...\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62742,7 +62742,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "The tip of his engorged dick, veins standing out,\nkissed the maiden's genitals. Phils twisted her\nface in anxiety and fear, but a trace of curiosity\nwas also present in her emotions."
+          "The tip of his engorged dick, veins standing out,\nkissed the maiden's genitals. Philis twisted her\nface in anxiety and fear, but a trace of curiosity\nwas also present in her emotions."
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62786,21 +62786,21 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Nn... kuu...─────────\""]
+        "parameters": ["\\OC[30]<Philis> \"Nn... kuu...─────────\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"─────It... hurts!\""]
+        "parameters": ["\\OC[30]<Philis> \"─────It... hurts!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 1, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "As the dick penetrated deeper into her vagina,\nPhils alone felt a tearing pain and sensation."
+          "As the dick penetrated deeper into her vagina,\nPhilis alone felt a tearing pain and sensation."
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62818,7 +62818,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Phils's eyes glazed over, her consciousness\nfocused so intensely on her lower abdomen that she\ncould hardly see what was in front of her, but she\nmanaged to reply."
+          "Philis's eyes glazed over, her consciousness\nfocused so intensely on her lower abdomen that she\ncould hardly see what was in front of her, but she\nmanaged to reply."
         ]
       },
       { "code": 230, "indent": 0, "parameters": [15] },
@@ -62827,7 +62827,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"───Yes... It hurt a bit... but I'm\nokay.\""
+          "\\OC[30]<Philis> \"───Yes... It hurt a bit... but I'm\nokay.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62843,7 +62843,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Yes... It's a very strange\nfeeling... My head is all fuzzy... and my hips are\ntingling...\""
+          "\\OC[30]<Philis> \"Yes... It's a very strange\nfeeling... My head is all fuzzy... and my hips are\ntingling...\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62851,7 +62851,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Manipulated Man> \"────Heh... That must mean\nPhils-chan's womb is also craving for dick.\""
+          "<Manipulated Man> \"────Heh... That must mean\nPhilis's womb is also craving for dick.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62866,7 +62866,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Yes, please...─────.\""]
+        "parameters": ["\\OC[30]<Philis> \"Yes, please...─────.\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 108, "indent": 0, "parameters": ["ピストン１"] },
@@ -62915,7 +62915,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Haah... haah...──uh, kuh...\nahh...───\""
+          "\\OC[30]<Philis> \"Haah... haah...──uh, kuh...\nahh...───\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -62924,21 +62924,21 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Manipulated Man> \"────Haah... ah, it's so tight!\nPhils-chan's tight pussy feels so good...!\""
+          "<Manipulated Man> \"────Haah... ah, it's so tight!\nPhilis's tight pussy feels so good...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Haah... haah...──────haah♥\""]
+        "parameters": ["\\OC[30]<Philis> \"Haah... haah...──────haah♥\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Can you... ejaculate with my\nbody...?\""
+          "\\OC[30]<Philis> \"Can you... ejaculate with my\nbody...?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -62954,7 +62954,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Manipulated Man> \"Sorry Phils-chan, I might not\nbe able to control myself! My hips won't stop!\""
+          "<Manipulated Man> \"Sorry Philis, I might not\nbe able to control myself! My hips won't stop!\""
         ]
       },
       { "code": 108, "indent": 0, "parameters": ["ピストン２　激しめ"] },
@@ -63004,14 +63004,14 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Ah, ugh, nnh♥ uh─────ahnn♥\""]
+        "parameters": ["\\OC[30]<Philis> \"Ah, ugh, nnh♥ uh─────ahnn♥\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Manipulated Man> \"─────Phils-chan seems to be\nfeeling good too, right? Your moans are so cute\nlike a small animal...! Makes me want to fuck you\neven more...!\""
+          "<Manipulated Man> \"─────Philis seems to be\nfeeling good too, right? Your moans are so cute\nlike a small animal...! Makes me want to fuck you\neven more...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63027,7 +63027,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"I don't know... nnh♥ My head's\ngoing blank────♥\""
+          "\\OC[30]<Philis> \"I don't know... nnh♥ My head's\ngoing blank────♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63050,7 +63050,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Haah♥ Haah♥ Th-that is──────♥♥\""]
+        "parameters": ["\\OC[30]<Philis> \"Haah♥ Haah♥ Th-that is──────♥♥\""]
       },
       { "code": 230, "indent": 0, "parameters": [15] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63066,7 +63066,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"No, that's not good! I haven't\ncast any contraception spells─────\""
+          "\\OC[30]<Philis> \"No, that's not good! I haven't\ncast any contraception spells─────\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63118,7 +63118,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Ah... ahh...─────────\""]
+        "parameters": ["\\OC[30]<Philis> \"Ah... ahh...─────────\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 2, 2] },
       {
@@ -63132,14 +63132,14 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> (Inside my stomach, it's hot...\nit's twitching so much...)"
+          "\\OC[30]<Philis> (Inside my stomach, it's hot...\nit's twitching so much...)"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> (This is sex...────)"]
+        "parameters": ["\\OC[30]<Philis> (This is sex...────)"]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 221, "indent": 0, "parameters": [] },
@@ -63190,7 +63190,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["Male Monk A: \"────This is... Phils-san's...!\""]
+        "parameters": ["Male Monk A: \"────This is... Philis's...!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -63231,7 +63231,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Ugh... hoo──────────\""]
+        "parameters": ["\\OC[30]<Philis> \"Ugh... hoo──────────\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63295,7 +63295,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Nha────ah...────♥\""]
+        "parameters": ["\\OC[30]<Philis> \"Nha────ah...────♥\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -63308,7 +63308,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Male Monk A> \"I-I've entered... into Philis-san's\nvagina...!\""
+          "<Male Monk A> \"I-I've entered... into Philis's\nvagina...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63442,7 +63442,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>(────Surprisingly... it's quite\ndelightful...─────"
+          "\\OC[30]<Philis>(────Surprisingly... it's quite\ndelightful...─────"
         ]
       },
       { "code": 230, "indent": 0, "parameters": [120] },
@@ -63480,7 +63480,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils>\"Haa, haa, fuu, haa───────"]
+        "parameters": ["\\OC[30]<Philis>\"Haa, haa, fuu, haa───────"]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -63501,7 +63501,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils>\"Haa... haa..., yes..., I'm feeling\nit...♥"
+          "\\OC[30]<Philis>\"Haa... haa..., yes..., I'm feeling\nit...♥"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63509,7 +63509,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Male Monk B>\"Really...! I'm so happy that Phils-\nsan is feeling good from my dick...!"
+          "<Male Monk B>\"Really...! I'm so happy that Philis\n is feeling good from my dick...!"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63541,7 +63541,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["<Male Monk B>\"Ahh────Phils-san!"]
+        "parameters": ["<Male Monk B>\"Ahh────Philis!"]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -63611,7 +63611,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Ahh───♥♥ Your cum... it's so\nwarm...────♥♥♥\""
+          "\\OC[30]<Philis> \"Ahh───♥♥ Your cum... it's so\nwarm...────♥♥♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63619,7 +63619,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[30]<Phils> \"Ejaculation... feels so\ngood...─────♥♥♥\""
+          "\\OC[30]<Philis> \"Ejaculation... feels so\ngood...─────♥♥♥\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -63662,7 +63662,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["\\OC[30]<Phils> \"Huu... huu...─────♥\""]
+        "parameters": ["\\OC[30]<Philis> \"Huu... huu...─────♥\""]
       },
       { "code": 230, "indent": 0, "parameters": [80] },
       { "code": 221, "indent": 0, "parameters": [] },
@@ -63676,7 +63676,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Phils herself hadn't realized that it was\namplified..."
+          "Philis herself hadn't realized that it was\namplified..."
         ]
       },
       { "code": 230, "indent": 0, "parameters": [120] },
@@ -63835,7 +63835,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Charismatic Man> \"Oh, scary. So if I'm gonna take\nadvantage of Rain-chan, now's my chance, huh?♪"
+          "<Charismatic Man> \"Oh, scary. So if I'm gonna take\nadvantage of Rain, now's my chance, huh?♪"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -63903,7 +63903,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Charismatic Man> \"Mmmh~~... Rain-chan's saliva is\nso tasty~~♥ Your breasts are super soft♥ What an\nerotic body♥"
+          "<Charismatic Man> \"Mmmh~~... Rain's saliva is\nso tasty~~♥ Your breasts are super soft♥ What an\nerotic body♥"
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -63983,7 +63983,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Charismatic Man> \"Nice reaction♥ You're really\nwet down there♪ To get this turned on just from a\nkiss, Rain-chan, you're so lewd♥"
+          "<Charismatic Man> \"Nice reaction♥ You're really\nwet down there♪ To get this turned on just from a\nkiss, Rain, you're so lewd♥"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64125,7 +64125,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Charismatic Man> \"You came so quickly even though\nwe haven't been at it for long. Rain-chan, you're\nso sensitive～. If I put my cock in, you'll feel\neven better～♪"
+          "<Charismatic Man> \"You came so quickly even though\nwe haven't been at it for long. Rain, you're\nso sensitive～. If I put my cock in, you'll feel\neven better～♪"
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64384,7 +64384,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirtatious Man> \"─────Rain-chan, seeing you feel\nso good makes me unable to hold back\nanymore...────────\""
+          "<Flirtatious Man> \"─────Rain, seeing you feel\nso good makes me unable to hold back\nanymore...────────\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64462,7 +64462,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirtatious Man> \"Ah~... Rain-chan's handjob\nfeels amazing...♥ Damn...♥\""
+          "<Flirtatious Man> \"Ah~... Rain's handjob\nfeels amazing...♥ Damn...♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64470,7 +64470,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirtatious Man> \"I've always thought Rain-chan\nwas super cute since the first time I saw her, but\nto think such a cute girl would make such a lewd\nface while French kissing and playing with my cock\nand her pussy at the same time, it's incredibly\nexciting♥\""
+          "<Flirtatious Man> \"I've always thought Rain\nwas super cute since the first time I saw her, but\nto think such a cute girl would make such a lewd\nface while French kissing and playing with my cock\nand her pussy at the same time, it's incredibly\nexciting♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64484,7 +64484,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirtatious Man> \"Ah~～I'm close, so close. Let's\ncum together, Rain-chan.\""
+          "<Flirtatious Man> \"Ah~～I'm close, so close. Let's\ncum together, Rain.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -64566,7 +64566,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirtatious Man> \"Ah, here comes the second\nwave────! Lend me your mouth, Rain-chan!\""
+          "<Flirtatious Man> \"Ah, here comes the second\nwave────! Lend me your mouth, Rain!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -65030,7 +65030,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "It's rough and feels so good, and Rain-chan, your\npussy is quite the masterpiece too."
+          "It's rough and feels so good, and Rain, your\npussy is quite the masterpiece too."
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -66714,7 +66714,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Photographer C: \"Rain-chan, you're so cute! The\nbest!!\""
+          "Photographer C: \"Rain, you're so cute! The\nbest!!\""
         ]
       },
       {
@@ -66904,7 +66904,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Photographer B> \"Rain-chan, it suits you so\nwell...! I didn't expect it to be this\nphotogenic...!\""
+          "<Photographer B> \"Rain, it suits you so\nwell...! I didn't expect it to be this\nphotogenic...!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -67882,7 +67882,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[31]<Rain> \"So watch me Jazz, the real me.\nWatch as \\N[7]-sama satisfies my uncontrollable\ndesires...♥\""
+          "\\OC[31]<Rain> \"So watch me Jazz, the real me.\nWatch as Lord \\N[7] satisfies my uncontrollable\ndesires...♥\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 1, 2] },
@@ -67964,7 +67964,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[31]<Rain> \"Ah, ah♥ ah─────haaah♥ This, this♥ I\nlove it♥♥♥ \\N[7]-sama's tentacle dick feels so\ngood♥♥♥\""
+          "\\OC[31]<Rain> \"Ah, ah♥ ah─────haaah♥ This, this♥ I\nlove it♥♥♥ Lord \\N[7]'s tentacle dick feels so\ngood♥♥♥\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [60] },
@@ -67982,7 +67982,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[5]<\\N[7]> \"Rain-san really loves my thing,\ndoesn't she? How about it? Compared to your ex-\nlover's thing. Which one can satisfy you more?\""
+          "\\OC[5]<\\N[7]> \"Rain really loves my thing,\ndoesn't she? How about it? Compared to your ex-\nlover's thing. Which one can satisfy you more?\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -67999,7 +67999,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\OC[5]<\\N[7]> \"Oh my. To think that you were\nlovers who loved each other so much!? You must\nhave been very frustrated, Rain-san.\""
+          "\\OC[5]<\\N[7]> \"Oh my. To think that you were\nlovers who loved each other so much!? You must\nhave been very frustrated, Rain.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -68819,7 +68819,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Soldier: \"Ra-Rain-san... it's too\nintense───────────\""
+          "Soldier: \"Ra-Rain... it's too\nintense───────────\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [60] },
@@ -69022,7 +69022,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["Soldier: \"─────Guh! Ra-Rain-san...?\""]
+        "parameters": ["Soldier: \"─────Guh! Ra-Rain...?\""]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -69153,7 +69153,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["Soldier: \"Ra-Rain-san...?\""]
+        "parameters": ["Soldier: \"Ra-Rain...?\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -69423,7 +69423,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<客> \"────Ah... that's good, Rain-chan. You have\nsuch a nice ass.\""
+          "<客> \"────Ah... that's good, Rain. You have\nsuch a nice ass.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -69714,7 +69714,7 @@
       {
         "code": 401,
         "indent": 0,
-        "parameters": ["Guest: \"Ughh... Rain-chan, you're too erotic...!\""]
+        "parameters": ["Guest: \"Ughh... Rain, you're too erotic...!\""]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
       {
@@ -69907,7 +69907,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Guest>: \"R-Rain-chan...! If you do it like\nthat────!\""
+          "<Guest>: \"R-Rain...! If you do it like\nthat────!\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -73591,7 +73591,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard B>\"Oh! There she is! Been waiting for ya, Rain-\nchan~~!\""
+          "\\N<Drunkard B>\"Oh! There she is! Been waiting for ya, Rain\n~~!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73660,7 +73660,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "<Drunkard C> \"Shut up, idiot! That's why we\ndecided to have Rain-chan judge!\""
+          "<Drunkard C> \"Shut up, idiot! That's why we\ndecided to have Rain judge!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73668,7 +73668,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "<Drunkard B> \"Alright, alright! So, Rain-chan,\nwhat do you think? Take a good look? You can even\ngrab it properly if you want??\""
+          "<Drunkard B> \"Alright, alright! So, Rain,\nwhat do you think? Take a good look? You can even\ngrab it properly if you want??\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73676,7 +73676,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "<Drunkard C> \"Yeah, that's a good idea! You gotta\njudge including the thickness from the backside\ntoo! Come on Rain-chan, grab it, grab it!\""
+          "<Drunkard C> \"Yeah, that's a good idea! You gotta\njudge including the thickness from the backside\ntoo! Come on Rain, grab it, grab it!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73700,7 +73700,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "<Drunkard B> \"That's right, if Rain-chan grabs it\nand judges properly, we'll put it away\nimmediately!\""
+          "<Drunkard B> \"That's right, if Rain grabs it\nand judges properly, we'll put it away\nimmediately!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73738,7 +73738,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "Drunkard B: \"Ohh... Rain-chan's hand is so\nwarm...♥\""
+          "Drunkard B: \"Ohh... Rain's hand is so\nwarm...♥\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -73934,7 +73934,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\CE[79]\\N<Drunkard B>\"Yes yes, thanks Rain-chan! I'm satisfied.\""
+          "\\CE[79]\\N<Drunkard B>\"Yes yes, thanks Rain! I'm satisfied.\""
         ]
       },
       {
@@ -73994,7 +73994,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard C>\"Tch... But well, I got Rain-chan to grab my dick\nso I'll let it slide!\""
+          "\\N<Drunkard C>\"Tch... But well, I got Rain to grab my dick\nso I'll let it slide!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -74002,7 +74002,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard B>\"Rain-chan always knows how to have fun! We'll ask\nyou again! Oh, and we don't have any orders right\nnow!\""
+          "\\N<Drunkard B>\"Rain always knows how to have fun! We'll ask\nyou again! Oh, and we don't have any orders right\nnow!\""
         ]
       },
       {
@@ -74222,7 +74222,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard B>\"Oh~~ Rain-chan! Finally, we meet again! Haha!\""
+          "\\N<Drunkard B>\"Oh~~ Rain! Finally, we meet again! Haha!\""
         ]
       },
       { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -74305,7 +74305,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard B>\"Then how about this, we'll only touch Rain-chan!\nThat's okay, right?\""
+          "\\N<Drunkard B>\"Then how about this, we'll only touch Rain!\nThat's okay, right?\""
         ]
       },
       { "code": 122, "indent": 2, "parameters": [87, 87, 0, 4, "\"006\""] },
@@ -74449,7 +74449,7 @@
       {
         "code": 401,
         "indent": 2,
-        "parameters": ["\\N<Drunkard C>\"Man~~ that was the best, Rain-chan!\""]
+        "parameters": ["\\N<Drunkard C>\"Man~~ that was the best, Rain!\""]
       },
       { "code": 122, "indent": 2, "parameters": [78, 78, 0, 0, 0] },
       { "code": 122, "indent": 2, "parameters": [85, 85, 0, 4, "\"004\""] },
@@ -74470,7 +74470,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Drunkard B>\"I get it, I get it. Because I want to have sex\nwith Rain-chan again!\""
+          "\\N<Drunkard B>\"I get it, I get it. Because I want to have sex\nwith Rain again!\""
         ]
       },
       { "code": 230, "indent": 2, "parameters": [30] },
@@ -74980,7 +74980,7 @@
         "code": 401,
         "indent": 2,
         "parameters": [
-          "\\N<Thuggish Man A>\"Oh, are you the famous Rain-chan?\""
+          "\\N<Thuggish Man A>\"Oh, are you the famous Rain?\""
         ]
       },
       { "code": 122, "indent": 2, "parameters": [87, 87, 0, 4, "\"006\""] },
@@ -75864,7 +75864,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Flirty light-brown-haired guy>: \"Your name was\nRain-chan, right? You give such an erotic blowjob.\nCould it be that you're quite the slut?\""
+          "<Flirty light-brown-haired guy>: \"Your name was\nRain, right? You give such an erotic blowjob.\nCould it be that you're quite the slut?\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [15] },
@@ -76084,7 +76084,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"Offering your pussy like\nthat, you really get it, Rain-chan♪ Or could it be\nthat you actually wanted to have sex outdoors?\""
+          "Flirty brown-haired guy: \"Offering your pussy like\nthat, you really get it, Rain♪ Or could it be\nthat you actually wanted to have sex outdoors?\""
         ]
       },
       { "code": 108, "indent": 0, "parameters": ["顔カットイン表示"] },
@@ -76107,7 +76107,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"Hmm, really? Well, it\ndoesn't matter to me, as long as I get to fuck\nRain-chan.\""
+          "Flirty brown-haired guy: \"Hmm, really? Well, it\ndoesn't matter to me, as long as I get to fuck\nRain.\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -76243,7 +76243,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"The blowjob was good,\nbut Rain-chan's pussy feels super amazing too♪\""
+          "Flirty brown-haired guy: \"The blowjob was good,\nbut Rain's pussy feels super amazing too♪\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -76251,7 +76251,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"But you know, Rain-chan,\nyou're pretty loud. Someone might come if you keep\nthat up?\""
+          "Flirty brown-haired guy: \"But you know, Rain,\nyou're pretty loud. Someone might come if you keep\nthat up?\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -76265,7 +76265,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"Well, maybe that's why\nyou're so wet. Rain-chan, you look so cool but you\npeep on others having sex and get your pussy wet,\nyou're a natural bitch!\""
+          "Flirty brown-haired guy: \"Well, maybe that's why\nyou're so wet. Rain, you look so cool but you\npeep on others having sex and get your pussy wet,\nyou're a natural bitch!\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [15] },
@@ -76291,7 +76291,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"But remember, Rain-chan,\nwhenever you want to fuck, I'm always ready to do\nit with you. Just say the word♪\""
+          "Flirty brown-haired guy: \"But remember, Rain,\nwhenever you want to fuck, I'm always ready to do\nit with you. Just say the word♪\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -76306,7 +76306,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"Ah~... here it comes.\nRain-chan's pussy is too good, I'm gonna cum.\""
+          "Flirty brown-haired guy: \"Ah~... here it comes.\nRain's pussy is too good, I'm gonna cum.\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [30] },
@@ -76363,7 +76363,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "Flirty brown-haired guy: \"I'm gonna cum inside\nyou, Rain-chan! I'm gonna shoot my cum right into\nyour womb~~!!\""
+          "Flirty brown-haired guy: \"I'm gonna cum inside\nyou, Rain! I'm gonna shoot my cum right into\nyour womb~~!!\""
         ]
       },
       { "code": 230, "indent": 0, "parameters": [15] },
@@ -77336,7 +77336,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "\\N<Drunkard B>\"Ahh~ That feels so good! Rain-chan's pussy is the\nbest!\""
+          "\\N<Drunkard B>\"Ahh~ That feels so good! Rain's pussy is the\nbest!\""
         ]
       },
       { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -79018,7 +79018,7 @@
         "code": 401,
         "indent": 0,
         "parameters": [
-          "<Green-haired Monk> \"Ahh, Rain-sama...! Rain-\nsamaa!!\""
+          "<Green-haired Monk> \"Ahh, Lady Rain...! Lady\nRainnn!!\""
         ]
       },
       { "code": 122, "indent": 0, "parameters": [499, 499, 0, 0, 1] },

--- a/www/data/Map017.json
+++ b/www/data/Map017.json
@@ -5754,7 +5754,7 @@
             {
               "code": 401,
               "indent": 3,
-              "parameters": ["Ah... Meryl-chan... ♥ thank goodness... ♥"]
+              "parameters": ["Ah... Meryl... ♥ thank goodness... ♥"]
             },
             { "code": 0, "indent": 3, "parameters": [] },
             { "code": 411, "indent": 2, "parameters": [] },

--- a/www/data/Map036.json
+++ b/www/data/Map036.json
@@ -11926,7 +11926,7 @@
                 1,
                 0,
                 4,
-                "'Lets talk to the chief guard at the guard station'"
+                "'Lets talk to the guard captain at the guard station'"
               ]
             },
             { "code": 117, "indent": 0, "parameters": [68] },

--- a/www/data/Map048.json
+++ b/www/data/Map048.json
@@ -8682,7 +8682,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>Don't worry. I have Caldo, Father Frist, Phils ,\nand Meryl with me. I'm sure we can figure\nsomething out."
+                "\\CE[79]\\OC[31]\\N<Rain>Don't worry. I have Caldo, Father Frist, Philis ,\nand Meryl with me. I'm sure we can figure\nsomething out."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -10540,7 +10540,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Rain!"]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Rain!"]
             },
             {
               "code": 205,
@@ -10598,7 +10598,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>You're awake! Are you feeling okay?"
+                "\\CE[94]\\OC[30]\\N<Philis>You're awake! Are you feeling okay?"
               ]
             },
             {
@@ -10652,7 +10652,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>No, it's nothing... but I'm glad you're safe...!"
+                "\\CE[94]\\OC[30]\\N<Philis>No, it's nothing... but I'm glad you're safe...!"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -10832,7 +10832,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>That 'discomfort' we've been experiencing... it\nwas the magic of that demon, huh."
+                "\\CE[94]\\OC[30]\\N<Philis>That 'discomfort' we've been experiencing... it\nwas the magic of that demon, huh."
               ]
             },
             { "code": 117, "indent": 0, "parameters": [73] },
@@ -10872,7 +10872,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Yes... I think it's the same as usual... I don't\nfeel like that spell called 'Nightmare Heaven' has\ndisappeared."
+                "\\CE[94]\\OC[30]\\N<Philis>Yes... I think it's the same as usual... I don't\nfeel like that spell called 'Nightmare Heaven' has\ndisappeared."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -10966,7 +10966,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Oh, Rain! How about we ask that man we rescued in\nthe dungeon for some information?"
+                "\\CE[94]\\OC[30]\\N<Philis>Oh, Rain! How about we ask that man we rescued in\nthe dungeon for some information?"
               ]
             },
             {
@@ -10997,7 +10997,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>That person is currently resting at the monastery\n\\C[0] next to the church. I'll go ahead and\nprepare, okay?"
+                "\\CE[94]\\OC[30]\\N<Philis>That person is currently resting at the monastery\n\\C[0] next to the church. I'll go ahead and\nprepare, okay?"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -11372,7 +11372,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\C[13]\\OC[31]\\N<Inner Rain>(For now, let's go to the monastery as Phils\nsuggested. I'm pretty sure she said it's next to\nthe church in the north.)"
+                "\\C[13]\\OC[31]\\N<Inner Rain>(For now, let's go to the monastery as Philis\nsuggested. I'm pretty sure she said it's next to\nthe church in the north.)"
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -11434,7 +11434,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\C[13]\\OC[31]\\N<Inner Rain>(For now, let's go to the monastery as Phils\nsuggested. I'm pretty sure she said it's next to\nthe church in the north.)"
+                "\\C[13]\\OC[31]\\N<Inner Rain>(For now, let's go to the monastery as Philis\nsuggested. I'm pretty sure she said it's next to\nthe church in the north.)"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },

--- a/www/data/Map049.json
+++ b/www/data/Map049.json
@@ -419,7 +419,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\C[13]\\OC[31]\\N<Inner Rain>(As Phils mentioned, there are several people who\nseem to be magicians... For now, let's see what\nthey have to say.)"
+                "\\C[13]\\OC[31]\\N<Inner Rain>(As Philis mentioned, there are several people who\nseem to be magicians... For now, let's see what\nthey have to say.)"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -3080,7 +3080,7 @@
               "code": 401,
               "indent": 5,
               "parameters": [
-                "\\CE[79]\\N<A flashy man>\"Oh, Rain-chan! You're still super sexy-cute♪\""
+                "\\CE[79]\\N<A flashy man>\"Oh, Rain! You're still super sexy-cute♪\""
               ]
             },
             {
@@ -3194,7 +3194,7 @@
               "code": 401,
               "indent": 5,
               "parameters": [
-                "\\N<A flashy man>\"Well then... if Rain-chan goes on a date with me\nagain, maybe I'll consider stopping♥\""
+                "\\N<A flashy man>\"Well then... if Rain goes on a date with me\nagain, maybe I'll consider stopping♥\""
               ]
             },
             { "code": 122, "indent": 5, "parameters": [78, 78, 0, 0, 0] },
@@ -3232,7 +3232,7 @@
               "code": 401,
               "indent": 5,
               "parameters": [
-                "\\N<A flashy man>\"If Rain-chan goes on a more \\C[27]\"grown-up\"\\C[0]\ndate with me than before, I'll stop hitting on the\ngirls at this gathering place for good...♥\""
+                "\\N<A flashy man>\"If Rain goes on a more \\C[27]\"grown-up\"\\C[0]\ndate with me than before, I'll stop hitting on the\ngirls at this gathering place for good...♥\""
               ]
             },
             { "code": 230, "indent": 5, "parameters": [30] },
@@ -3271,7 +3271,7 @@
               "code": 401,
               "indent": 5,
               "parameters": [
-                "\\N<A flashy man>\"It's all good♪ Honestly, spending time with just\nRain-chan is way more appealing than playing with\nall the staff girls♥\""
+                "\\N<A flashy man>\"It's all good♪ Honestly, spending time with just\nRain is way more appealing than playing with\nall the staff girls♥\""
               ]
             },
             { "code": 117, "indent": 5, "parameters": [97] },
@@ -5217,7 +5217,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\N<A flashy man>\"Need? More like, you're super strong and super\ncute- How could I not hit on you? Since we've met\nby chance, let's go out for drinks, Rain-chan! My\ntreat! ♪\""
+                "\\N<A flashy man>\"Need? More like, you're super strong and super\ncute- How could I not hit on you? Since we've met\nby chance, let's go out for drinks, Rain! My\ntreat! ♪\""
               ]
             },
             { "code": 230, "indent": 4, "parameters": [30] },
@@ -5422,7 +5422,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\CE[79]\\N<A flashy man>\"Nah-, she didn't say that herself, right?\nBesides, I really want to hang out with her. Rain-\nchan doesn't have the right to stop me, does she?\""
+                "\\CE[79]\\N<A flashy man>\"Nah-, she didn't say that herself, right?\nBesides, I really want to hang out with her. Rain\n doesn't have the right to stop me, does she?\""
               ]
             },
             { "code": 101, "indent": 4, "parameters": ["", 0, 0, 2] },
@@ -5460,7 +5460,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\N<A flashy man>\"If Rain-chan agrees to hang out with me then of\ncourse I'll leave right away- but if not, could\nyou keep it down a bit?\""
+                "\\N<A flashy man>\"If Rain agrees to hang out with me then of\ncourse I'll leave right away- but if not, could\nyou keep it down a bit?\""
               ]
             },
             {
@@ -5793,7 +5793,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\N<A flashy man>\"Oh, Rain-chan! Yoohoo, I've been waiting for\nyou♪\""
+                "\\N<A flashy man>\"Oh, Rain! Yoohoo, I've been waiting for\nyou♪\""
               ]
             },
             { "code": 122, "indent": 6, "parameters": [78, 78, 0, 0, 0] },
@@ -5935,7 +5935,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\N<A flashy man>\"Why? Because you're the one who made it so I\ncan't invite other girls. And nobody said I can't\ninvite Rain-chan♪\""
+                "\\N<A flashy man>\"Why? Because you're the one who made it so I\ncan't invite other girls. And nobody said I can't\ninvite Rain♪\""
               ]
             },
             {
@@ -5966,7 +5966,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\CE[79]\\N<A flashy man>\"Eh- seriously? Since I'm restricted from inviting\nother girls, come on Rain-chan, keep me company.\""
+                "\\CE[79]\\N<A flashy man>\"Eh- seriously? Since I'm restricted from inviting\nother girls, come on Rain, keep me company.\""
               ]
             },
             { "code": 101, "indent": 6, "parameters": ["", 0, 0, 2] },
@@ -6061,7 +6061,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\N<A flashy man>\"So if I break the promise and persistently invite\nother girls, will that mean I can go on a date\nwith Rain-chan?\""
+                "\\N<A flashy man>\"So if I break the promise and persistently invite\nother girls, will that mean I can go on a date\nwith Rain?\""
               ]
             },
             { "code": 213, "indent": 6, "parameters": [-1, 1, true] },
@@ -6104,7 +6104,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\CE[78]\\N<A flashy man>\"If Rain-chan says no, then there's no merit in\nkeeping the promise, right?\""
+                "\\CE[78]\\N<A flashy man>\"If Rain says no, then there's no merit in\nkeeping the promise, right?\""
               ]
             },
             { "code": 101, "indent": 6, "parameters": ["", 0, 0, 2] },

--- a/www/data/Map062.json
+++ b/www/data/Map062.json
@@ -788,7 +788,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>This is... the infamous dungeon."
+                "\\CE[94]\\OC[30]\\N<Philis>This is... the infamous dungeon."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -796,7 +796,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>I've heard that several adventurers have already\ntried to conquer it, but they couldn't progress\nbecause there are many strong monsters."
+                "\\OC[30]\\N<Philis>I've heard that several adventurers have already\ntried to conquer it, but they couldn't progress\nbecause there are many strong monsters."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -865,7 +865,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>Yes, I can also use defensive magic, so it's okay.\nI'll wait for you here."
+                "\\CE[79]\\OC[30]\\N<Philis>Yes, I can also use defensive magic, so it's okay.\nI'll wait for you here."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -879,7 +879,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Please be careful... May the divine blessings of\nthe Holy Demon be with you."
+                "\\CE[94]\\OC[30]\\N<Philis>Please be careful... May the divine blessings of\nthe Holy Demon be with you."
               ]
             },
             {
@@ -1147,7 +1147,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>With this... you don't seem to have any major\ninjuries, so if you rest properly, you should be\nfine."
+                "\\CE[94]\\OC[30]\\N<Philis>With this... you don't seem to have any major\ninjuries, so if you rest properly, you should be\nfine."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1187,7 +1187,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Rain, are you okay..."]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Rain, are you okay..."]
             },
             { "code": 230, "indent": 0, "parameters": [60] },
             {
@@ -1264,7 +1264,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Welcome back, Rain!"]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Welcome back, Rain!"]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
             { "code": 117, "indent": 0, "parameters": [73] },
@@ -1282,7 +1282,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>!! Your complexion looks really bad...! Did you\nget poisoned!? I'll detoxify you right away!"
+                "\\OC[30]\\N<Philis>!! Your complexion looks really bad...! Did you\nget poisoned!? I'll detoxify you right away!"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [] },
@@ -1297,7 +1297,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[95]\\OC[30]\\N<Phils>!! R-Rain... your appearance...!?"
+                "\\CE[95]\\OC[30]\\N<Philis>!! R-Rain... your appearance...!?"
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
@@ -1305,7 +1305,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>And your complexion looks really bad... Did you\nget poisoned!? I'll detoxify you right away!"
+                "\\OC[30]\\N<Philis>And your complexion looks really bad... Did you\nget poisoned!? I'll detoxify you right away!"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [] },
@@ -1388,7 +1388,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Rain! Rain! Please hang on!!"]
+              "parameters": ["\\OC[30]\\N<Philis>Rain! Rain! Please hang on!!"]
             },
             { "code": 117, "indent": 0, "parameters": [80] },
             { "code": 230, "indent": 0, "parameters": [120] },

--- a/www/data/Map063.json
+++ b/www/data/Map063.json
@@ -2401,7 +2401,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[78]\\OC[31]\\C[13]\\N<Inner Rain>(First, I need to go to the \\C[17]guard\nstation\\C[13] and talk to the chief guard. If I\nremember correctly, they said it's on the left\nhand side right after entering\n\\C[17]town\\C[13]...)"
+                "\\CE[79]\\CE[78]\\OC[31]\\C[13]\\N<Inner Rain>(First, I need to go to the \\C[17]guard\nstation\\C[13] and talk to the guard captain. If I\nremember correctly, they said it's on the left\nhand side right after entering\n\\C[17]town\\C[13]...)"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2418,7 +2418,7 @@
                 1,
                 0,
                 4,
-                "'Lets talk to the chief guard at the guard station'"
+                "'Lets talk to the guard captain at the guard station'"
               ]
             },
             { "code": 117, "indent": 0, "parameters": [68] },
@@ -9199,7 +9199,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\EMPI will do my best to become a splendid priest\nlike Mr. Frist...! If I do that, even Phils ..."
+                "\\EMPI will do my best to become a splendid priest\nlike Mr. Frist...! If I do that, even Philis ..."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },

--- a/www/data/Map064.json
+++ b/www/data/Map064.json
@@ -4945,7 +4945,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<A flashy man>\"───Rain-chan, are you okay? Looks like you drank\na bit too much.\""
+                "\\N<A flashy man>\"───Rain, are you okay? Looks like you drank\na bit too much.\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -5019,7 +5019,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<A flashy man>\"Nah─... I mean, Rain-chan, you're just so\ncute...\""
+                "\\N<A flashy man>\"Nah─... I mean, Rain, you're just so\ncute...\""
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -5149,7 +5149,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\N<A flashy man>\"Tch─, got it... But in exchange, Rain-chan, go on\nanother date with me! Please!\""
+                "\\CE[79]\\N<A flashy man>\"Tch─, got it... But in exchange, Rain, go on\nanother date with me! Please!\""
               ]
             },
             {
@@ -5193,7 +5193,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[78]\\N<A flashy man>\"Well then, since Rain-chan's sobered up a bit,\nit's a shame but let's call it a night for now.\nSee ya later～♪\""
+                "\\CE[78]\\N<A flashy man>\"Well then, since Rain's sobered up a bit,\nit's a shame but let's call it a night for now.\nSee ya later～♪\""
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -5477,7 +5477,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<A flashy man>\"Eh~~!? After all this, we're not having sex!?\nCome on, Rain-chan, you want it too, right!?\""
+                "\\N<A flashy man>\"Eh~~!? After all this, we're not having sex!?\nCome on, Rain, you want it too, right!?\""
               ]
             },
             {

--- a/www/data/Map073.json
+++ b/www/data/Map073.json
@@ -610,7 +610,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\n<Chief Guard>Are you Rain, the holy knight? Thank you for\ncoming all this way."
+                "\\n<Guard Captain>Are you Rain, the holy knight? Thank you for\ncoming all this way."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -619,7 +619,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\n<Chief Guard>I am Caldo, the chief guard. Nice to meet you."
+                "\\n<Guard Captain>I am Caldo, the guard captain. Nice to meet you."
               ]
             },
             {
@@ -1007,7 +1007,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\n<Caldo>I'm sorry, I also want to use my legs, but there\nare too many documents to check... I apologize for\nmaking the Holy Knight-sama run around!"
+                "\\n<Caldo>I'm sorry, I also want to use my legs, but there\nare too many documents to check... I apologize for\nmaking the Holy Knight run around!"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1245,7 +1245,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Caldo>I see... Understood. I will inform Meryl and Phils\nabout this. There are also traps in the northeast\ndungeon, so please be careful!"
+                "\\n<Caldo>I see... Understood. I will inform Meryl and Philis\nabout this. There are also traps in the northeast\ndungeon, so please be careful!"
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -2377,7 +2377,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>And besides, Meryl informed us about something\nimportant that concerns the peace of this town. We\ncan't do anything that would exclude someone like\nthat."
+                "\\CE[94]\\OC[30]\\N<Philis>And besides, Meryl informed us about something\nimportant that concerns the peace of this town. We\ncan't do anything that would exclude someone like\nthat."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2475,7 +2475,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>But, Rain, it's reckless to infiltrate the enemy's\nhideout alone!"
+                "\\CE[94]\\OC[30]\\N<Philis>But, Rain, it's reckless to infiltrate the enemy's\nhideout alone!"
               ]
             },
             {
@@ -2699,7 +2699,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\n<Frist>Let's make sure we can support Rain. I'm sure\nSaint Phils will also cooperate."
+                "\\n<Frist>Let's make sure we can support Rain. I'm sure\nSaint Philis will also cooperate."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2742,7 +2742,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Yes! I will do everything I can right now...!"
+                "\\CE[94]\\OC[30]\\N<Philis>Yes! I will do everything I can right now...!"
               ]
             },
             {

--- a/www/data/Map074.json
+++ b/www/data/Map074.json
@@ -1437,7 +1437,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>\"\\N[4]-san, have you been able to extract any\ninformation?\""
+                "\\CE[79]\\OC[31]\\N<Rain>\"\\N[4], have you been able to extract any\ninformation?\""
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },

--- a/www/data/Map075.json
+++ b/www/data/Map075.json
@@ -1489,7 +1489,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[84]\\n<Frist>That's right. Sister Phils was the one who\nnoticed. She also found the dungeon."
+                "\\CE[79]\\CE[84]\\n<Frist>That's right. Sister Philis was the one who\nnoticed. She also found the dungeon."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1521,7 +1521,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>Sister Phils, are you here? Can you come over\nhere?"
+                "\\n<Frist>Sister Philis, are you here? Can you come over\nhere?"
               ]
             },
             { "code": 230, "indent": 2, "parameters": [40] },
@@ -1559,7 +1559,7 @@
             {
               "code": 401,
               "indent": 2,
-              "parameters": ["\\n<Fristo>Sister Phils, can you come over here?"]
+              "parameters": ["\\n<Fristo>Sister Philis, can you come over here?"]
             },
             { "code": 230, "indent": 2, "parameters": [30] },
             {
@@ -1627,7 +1627,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>I-I'm sorry! I kept you waiting! I'm sorry, I was\nso focused on my work that I didn't hear..."
+                "\\OC[30]\\N<Philis>I-I'm sorry! I kept you waiting! I'm sorry, I was\nso focused on my work that I didn't hear..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1641,7 +1641,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>It's alright. Rain, this is Sister\n\\C[17]Phils\\C[0], the one who discovered the\nabnormality."
+                "\\n<Frist>It's alright. Rain, this is Sister\n\\C[17]Philis\\C[0], the one who discovered the\nabnormality."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1714,7 +1714,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>N-Nice to meet you too... for the first time!"
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>N-Nice to meet you too... for the first time!"
               ]
             },
             { "code": 213, "indent": 2, "parameters": [14, 13, false] },
@@ -1723,7 +1723,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>Oh my, the Holy Knights truly live up to their\nreputation... I can feel such incredible magical\npower!"
+                "\\OC[30]\\N<Philis>Oh my, the Holy Knights truly live up to their\nreputation... I can feel such incredible magical\npower!"
               ]
             },
             { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -1731,7 +1731,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>Sister Phils, calm down. Can you please report to\nRain about the abnormality in the town and the\ndungeon right away?"
+                "\\n<Frist>Sister Philis, calm down. Can you please report to\nRain about the abnormality in the town and the\ndungeon right away?"
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1745,7 +1745,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Y-Yes, I'm sorry! It's my first time meeting a\nHoly Knight, so..."
+                "\\CE[94]\\OC[30]\\N<Philis>Y-Yes, I'm sorry! It's my first time meeting a\nHoly Knight, so..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1773,7 +1773,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Um... I started feeling a sense of discomfort\nabout half a year ago. At first, I just thought it\nwas because the days were getting colder..."
+                "\\CE[94]\\OC[30]\\N<Philis>Um... I started feeling a sense of discomfort\nabout half a year ago. At first, I just thought it\nwas because the days were getting colder..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1830,7 +1830,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>Yes! That's exactly it. At first, it seemed like I\nwas the only one feeling it, but about three\nmonths ago, everyone else started sensing\nsomething too."
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>Yes! That's exactly it. At first, it seemed like I\nwas the only one feeling it, but about three\nmonths ago, everyone else started sensing\nsomething too."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1845,7 +1845,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>So, I often go for walks in the forest and gather\nherbs, but it's clear that there has been an\nincrease in monsters compared to a year ago."
+                "\\CE[94]\\OC[30]\\N<Philis>So, I often go for walks in the forest and gather\nherbs, but it's clear that there has been an\nincrease in monsters compared to a year ago."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1854,7 +1854,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>Because I was scared, I took a different path than\nusual and happened to find a dungeon."
+                "\\OC[30]\\N<Philis>Because I was scared, I took a different path than\nusual and happened to find a dungeon."
               ]
             },
             {
@@ -1885,7 +1885,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>Sister Phils was the first to feel a sense of\ndiscomfort, probably because she has a\nparticularly strong divine protection even within\nthe church."
+                "\\n<Frist>Sister Philis was the first to feel a sense of\ndiscomfort, probably because she has a\nparticularly strong divine protection even within\nthe church."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1931,7 +1931,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>When I spoke to Chief Caldo and compared the\nreports, it matched with the time when the town's\npublic order started deteriorating and Sister\nPhils began feeling a sense of discomfort."
+                "\\n<Frist>When I spoke to Captain Caldo and compared the\nreports, it matched with the time when the town's\npublic order started deteriorating and Sister\nPhilis began feeling a sense of discomfort."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1993,7 +1993,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>Sister Phils, I will be your escort. Can you guide\nus, please?"
+                "\\CE[79]\\OC[31]\\N<Rain>Sister Philis, I will be your escort. Can you guide\nus, please?"
               ]
             },
             {
@@ -2038,7 +2038,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>Yes, of course!"
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>Yes, of course!"
               ]
             },
             { "code": 230, "indent": 2, "parameters": [15] },
@@ -2093,7 +2093,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[94]\\n<Frist>Sister Phils can also use healing and defensive\nmagic, but, both of you please be careful. We\ndon't know what might happen..."
+                "\\CE[79]\\CE[94]\\n<Frist>Sister Philis can also use healing and defensive\nmagic, but, both of you please be careful. We\ndon't know what might happen..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -2134,7 +2134,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\n<Frist>Above all, both Rain and Sister Phils have\nbeautiful bodies. If anything were to happen to\nthat physical beauty, it would be a great loss for\nhumanity!"
+                "\\n<Frist>Above all, both Rain and Sister Philis have\nbeautiful bodies. If anything were to happen to\nthat physical beauty, it would be a great loss for\nhumanity!"
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -3286,7 +3286,7 @@
               "code": 401,
               "indent": 3,
               "parameters": [
-                "Phils: How much should we use the power of\nprotection?"
+                "Philis: How much should we use the power of\nprotection?"
               ]
             },
             {
@@ -3448,7 +3448,7 @@
               "code": 401,
               "indent": 3,
               "parameters": [
-                "\\n<\\n[5]>\"Oh, it seems that Rain-san doesn't need my power\nright now.\""
+                "\\n<\\n[5]>\"Oh, it seems that Rain doesn't need my power\nright now.\""
               ]
             },
             { "code": 0, "indent": 3, "parameters": [""] },
@@ -4288,7 +4288,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[78]\\CE[79]\\OC[31]\\N<Rain>Confession, huh? Well, I do have the authority for\nthat, so it's fine if you want to confess to me.\nBut are you sure you don't want to confess to\nPhils instead?"
+                "\\CE[78]\\CE[79]\\OC[31]\\N<Rain>Confession, huh? Well, I do have the authority for\nthat, so it's fine if you want to confess to me.\nBut are you sure you don't want to confess to\nPhilis instead?"
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },

--- a/www/data/Map077.json
+++ b/www/data/Map077.json
@@ -444,7 +444,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>The adventurer's guild is located \\C[17] southeast\nfrom here. I will also listen to the stories from\nthose who visit the church."
+                "\\OC[30]\\N<Philis>The adventurer's guild is located \\C[17] southeast\nfrom here. I will also listen to the stories from\nthose who visit the church."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -455,7 +455,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>So far it seems like we at the monastery haven't\nbeen affected by 'Nightmare Heaven' much. This is\nalso thanks to the blessings of the Holy Demon."
+                "\\OC[30]\\N<Philis>So far it seems like we at the monastery haven't\nbeen affected by 'Nightmare Heaven' much. This is\nalso thanks to the blessings of the Holy Demon."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -464,7 +464,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>May Rain continue to be blessed."
+                "\\OC[30]\\N<Philis>May Rain continue to be blessed."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [] },
@@ -570,7 +570,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>They have calmed down quite a bit. Although they\nare still staying in a private room, there\nshouldn't be any issues with having everyday\nconversations."
+                "\\CE[94]\\OC[30]\\N<Philis>They have calmed down quite a bit. Although they\nare still staying in a private room, there\nshouldn't be any issues with having everyday\nconversations."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -584,7 +584,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>However, it seems like they don't remember much\nabout what happened in the dungeon, so it's\nunlikely that we'll be able to gather much\ninformation..."
+                "\\CE[94]\\OC[30]\\N<Philis>However, it seems like they don't remember much\nabout what happened in the dungeon, so it's\nunlikely that we'll be able to gather much\ninformation..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -615,7 +615,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Yes, that's right. I can't dispel the curse right\nnow, but I will diligently find a way to deal with\nit and show you."
+                "\\CE[94]\\OC[30]\\N<Philis>Yes, that's right. I can't dispel the curse right\nnow, but I will diligently find a way to deal with\nit and show you."
               ]
             },
             { "code": 101, "indent": 2, "parameters": ["", 0, 0, 2] },
@@ -631,7 +631,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\OC[30]\\N<Phils>Yes, take care. May the blessings of the Holy\nDemon be with you."
+                "\\OC[30]\\N<Philis>Yes, take care. May the blessings of the Holy\nDemon be with you."
               ]
             },
             { "code": 117, "indent": 2, "parameters": [97] },
@@ -722,7 +722,7 @@
             {
               "code": 401,
               "indent": 2,
-              "parameters": ["\\OC[30]\\N<Phils>「...──────────"]
+              "parameters": ["\\OC[30]\\N<Philis>「...──────────"]
             },
             { "code": 230, "indent": 2, "parameters": [15] },
             {
@@ -740,7 +740,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Phils...? Are you spacing out? Are you okay...?"
+                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Philis...? Are you spacing out? Are you okay...?"
               ]
             },
             {
@@ -758,7 +758,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\CE[96]\\OC[30]\\N<Phils>Ah, s-sorry...! I-I'm fine...! I was just lost in\nthought..."
+                "\\CE[94]\\CE[96]\\OC[30]\\N<Philis>Ah, s-sorry...! I-I'm fine...! I was just lost in\nthought..."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -882,7 +882,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>Phils, I came to check on you. How is that\nadventurer doing?"
+                "\\CE[79]\\OC[31]\\N<Rain>Philis, I came to check on you. How is that\nadventurer doing?"
               ]
             },
             { "code": 122, "indent": 1, "parameters": [109, 109, 0, 0, 6] },
@@ -906,7 +906,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>S-So, what happened after that... umm...─────"
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>S-So, what happened after that... umm...─────"
               ]
             },
             {
@@ -919,7 +919,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Yes, umm... well, I think they're doing fine and\nstarting to calm down a bit."
+                "\\CE[94]\\OC[30]\\N<Philis>Yes, umm... well, I think they're doing fine and\nstarting to calm down a bit."
               ]
             },
             { "code": 213, "indent": 1, "parameters": [-1, 2, false] },
@@ -947,7 +947,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>N-No... umm... nothing of the sort ...────. It's\njust that, I'm getting worn out from 'treatment',\nso I might be a little tired..."
+                "\\CE[94]\\OC[30]\\N<Philis>N-No... umm... nothing of the sort ...────. It's\njust that, I'm getting worn out from 'treatment',\nso I might be a little tired..."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -961,7 +961,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>I see... Phils is the only one capable of\nprotecting against 'Nightmare Heaven' at the\nmonastery... It must be putting a lot of strain on\nyou."
+                "\\CE[79]\\OC[31]\\N<Rain>I see... Philis is the only one capable of\nprotecting against 'Nightmare Heaven' at the\nmonastery... It must be putting a lot of strain on\nyou."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1071,7 +1071,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\OC[30]\\N<Phils>Ah...─────"]
+              "parameters": ["\\OC[30]\\N<Philis>Ah...─────"]
             },
             { "code": 213, "indent": 1, "parameters": [0, 8, true] },
             { "code": 230, "indent": 1, "parameters": [60] },
@@ -1081,7 +1081,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>(────I, I can't say it... that we're doing...\nnaughty things and helping each other reach\nclimax...)"
+                "\\OC[30]\\N<Philis>(────I, I can't say it... that we're doing...\nnaughty things and helping each other reach\nclimax...)"
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
@@ -1089,7 +1089,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>(But, he said that doing that has helped him calm\ndown quite a bit...Since we've come this far, I\ncan't just stop now...)"
+                "\\OC[30]\\N<Philis>(But, he said that doing that has helped him calm\ndown quite a bit...Since we've come this far, I\ncan't just stop now...)"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1098,7 +1098,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>(If I can ward off the power of Nightmare Heaven\nusing protection and assistance... then, I have to\ndo my best...I can't just rely on Rain\ncompletely...)"
+                "\\OC[30]\\N<Philis>(If I can ward off the power of Nightmare Heaven\nusing protection and assistance... then, I have to\ndo my best...I can't just rely on Rain\ncompletely...)"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1312,7 +1312,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>Yes... It seems difficult to completely prevent\n'Nightmare Heaven'..."
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>Yes... It seems difficult to completely prevent\n'Nightmare Heaven'..."
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
@@ -1320,7 +1320,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>That magic seems to constantly circulate through\nspace like a gas, so even if we temporarily negate\nits effects, it will still amplify desires again\nover time..."
+                "\\OC[30]\\N<Philis>That magic seems to constantly circulate through\nspace like a gas, so even if we temporarily negate\nits effects, it will still amplify desires again\nover time..."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1335,7 +1335,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>By the way... I think places and people protected\nby the divine blessings are relatively safe, but\nhow do we deal with those who are not protected?"
+                "\\CE[94]\\OC[30]\\N<Philis>By the way... I think places and people protected\nby the divine blessings are relatively safe, but\nhow do we deal with those who are not protected?"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1379,7 +1379,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\CE[94]\\CE[95]\\OC[30]\\N<Phils>Uh──────"]
+              "parameters": ["\\CE[94]\\CE[95]\\OC[30]\\N<Philis>Uh──────"]
             },
             {
               "code": 122,
@@ -1405,7 +1405,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>───S-So, that means... something lewd─────"
+                "\\CE[94]\\OC[30]\\N<Philis>───S-So, that means... something lewd─────"
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
@@ -1440,7 +1440,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>I see... I understand..."
+                "\\CE[94]\\OC[30]\\N<Philis>I see... I understand..."
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
@@ -1462,7 +1462,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Y-Yes, that's right...!  No, sacrificing myself to\nprotect the people of the town from the clutches\nof evil...!"
+                "\\CE[94]\\OC[30]\\N<Philis>Y-Yes, that's right...!  No, sacrificing myself to\nprotect the people of the town from the clutches\nof evil...!"
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1484,7 +1484,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Yes... But... please take good care of your\nbody... If you need any treatment, please let me\nknow anytime..."
+                "\\CE[94]\\OC[30]\\N<Philis>Yes... But... please take good care of your\nbody... If you need any treatment, please let me\nknow anytime..."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -1610,7 +1610,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>「...──────────"]
+              "parameters": ["\\OC[30]\\N<Philis>「...──────────"]
             },
             { "code": 230, "indent": 0, "parameters": [15] },
             {
@@ -1628,7 +1628,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Phils... Your face is all red, isn't it?"
+                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Philis... Your face is all red, isn't it?"
               ]
             },
             {
@@ -1641,7 +1641,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\CE[96]\\OC[30]\\N<Phils>Eh... Is that so? Well, there's nothing wrong with\nme..."
+                "\\CE[94]\\CE[96]\\OC[30]\\N<Philis>Eh... Is that so? Well, there's nothing wrong with\nme..."
               ]
             },
             {
@@ -1792,7 +1792,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>Rain... um, I'm having trouble with where to\nlook... so if you could wear clothing with a\nlittle less exposure, I would appreciate it..."
+                "\\N<Philis>Rain... um, I'm having trouble with where to\nlook... so if you could wear clothing with a\nlittle less exposure, I would appreciate it..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2605,7 +2605,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\CE[79]\\OC[30]\\N<Phils>I see... but that person is the victim, so it\nwould be pitiful to put them in a prison cell..."
+                "\\CE[94]\\CE[79]\\OC[30]\\N<Philis>I see... but that person is the victim, so it\nwould be pitiful to put them in a prison cell..."
               ]
             },
             {
@@ -2618,7 +2618,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Besides, there are other monks here, so I'm sure\nit'll be fine!"
+                "\\CE[94]\\OC[30]\\N<Philis>Besides, there are other monks here, so I'm sure\nit'll be fine!"
               ]
             },
             {
@@ -2654,7 +2654,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\CE[79]\\OC[30]\\N<Phils>Yes, thank you."
+                "\\CE[94]\\CE[79]\\OC[30]\\N<Philis>Yes, thank you."
               ]
             },
             {
@@ -2667,7 +2667,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Rain, what are you going to do from now on?"
+                "\\CE[94]\\OC[30]\\N<Philis>Rain, what are you going to do from now on?"
               ]
             },
             {
@@ -2722,7 +2722,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[78]\\CE[79]\\CE[84]\\OC[31]\\N<Rain>But, Phils' treatment has slightly alleviated his\nsymptoms. And the fact that he can resist with\nmagic and mental strength like me means that there\nmust be a solution."
+                "\\CE[78]\\CE[79]\\CE[84]\\OC[31]\\N<Rain>But, Philis' treatment has slightly alleviated his\nsymptoms. And the fact that he can resist with\nmagic and mental strength like me means that there\nmust be a solution."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2750,7 +2750,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>I see...! If we can analyze it, we might be able\nto find a way to dispel the curse!"
+                "\\CE[94]\\OC[30]\\N<Philis>I see...! If we can analyze it, we might be able\nto find a way to dispel the curse!"
               ]
             },
             {
@@ -2786,7 +2786,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>In that case, there is an Adventurer's Guild in\nthis town located southeast from here, there might\nbe some magicians there."
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>In that case, there is an Adventurer's Guild in\nthis town located southeast from here, there might\nbe some magicians there."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2813,7 +2813,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>I'm sorry for being a burden... I don't seem to be\nof much help right now..."
+                "\\CE[94]\\OC[30]\\N<Philis>I'm sorry for being a burden... I don't seem to be\nof much help right now..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2832,7 +2832,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[84]\\CE[78]\\OC[31]\\N<Rain>No, I haven't been able to do anything yet either.\nPhils, I'm counting on you to take care of him on\nthe second floor."
+                "\\CE[79]\\CE[84]\\CE[78]\\OC[31]\\N<Rain>No, I haven't been able to do anything yet either.\nPhilis, I'm counting on you to take care of him on\nthe second floor."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2846,7 +2846,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>All right. May the blessings of the Holy Demon be\nwith us."
+                "\\CE[94]\\OC[30]\\N<Philis>All right. May the blessings of the Holy Demon be\nwith us."
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -3073,7 +3073,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<\\N[5]>\"But, thank goodness Sister Phils and Rain-san\nhave both returned safely. Let's first rejoice in\nthat.\""
+                "\\N<\\N[5]>\"But, thank goodness Sister Philis and Rain\nhave both returned safely. Let's first rejoice in\nthat.\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3081,7 +3081,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<\\N[5]>\"However, Sister Phils, you've been too reckless.\nDespite the situation, going off alone like\nthat...\""
+                "\\N<\\N[5]>\"However, Sister Philis, you've been too reckless.\nDespite the situation, going off alone like\nthat...\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3089,7 +3089,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Frist>However, I'm glad that Sister Phils and Rain have\nboth returned safely. First, let's rejoice in that\nfact."
+                "\\N<Frist>However, I'm glad that Sister Philis and Rain have\nboth returned safely. First, let's rejoice in that\nfact."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -3098,7 +3098,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Frist>However, Sister Phils, you're being too reckless.\nEven considering the circumstances, going alone\nlike that..."
+                "\\N<Frist>However, Sister Philis, you're being too reckless.\nEven considering the circumstances, going alone\nlike that..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3106,7 +3106,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>I'm sorry... but if we continue like this..."
+                "\\N<Philis>I'm sorry... but if we continue like this..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3130,7 +3130,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Rain>Yes... Since the thief was always one step ahead\nof me and Phils, there's a high possibility that\nwe're being watched. If we act recklessly, we'll\njust end up getting in the way again..."
+                "\\N<Rain>Yes... Since the thief was always one step ahead\nof me and Philis, there's a high possibility that\nwe're being watched. If we act recklessly, we'll\njust end up getting in the way again..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -3151,7 +3151,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>I was able to make one with the clear crystal we\nretrieved. I think it's better if Rain has it."
+                "\\N<Philis>I was able to make one with the clear crystal we\nretrieved. I think it's better if Rain has it."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3159,7 +3159,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>It should be able to prevent some 'Desire\nManipulation Techniques', and although it's only\nonce, if you break it, a temporarily powerful\nprotective force will be activated!"
+                "\\N<Philis>It should be able to prevent some 'Desire\nManipulation Techniques', and although it's only\nonce, if you break it, a temporarily powerful\nprotective force will be activated!"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3175,7 +3175,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>I hate to say this... but Rain, please be careful\nnot to push yourself too hard!"
+                "\\N<Philis>I hate to say this... but Rain, please be careful\nnot to push yourself too hard!"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },

--- a/www/data/Map078.json
+++ b/www/data/Map078.json
@@ -571,7 +571,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>This is Phils. Can I come in?"
+                "\\CE[79]\\OC[30]\\N<Philis>This is Philis. Can I come in?"
               ]
             },
             {
@@ -766,7 +766,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Hey Phils, I'm glad you came today too."
+                "\\N<Manipulated Man>Hey Philis, I'm glad you came today too."
               ]
             },
             {
@@ -779,7 +779,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>No, I apologize for the inconvenience."
+                "\\CE[79]\\OC[30]\\N<Philis>No, I apologize for the inconvenience."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -795,7 +795,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>But, if Phils comes to see me like this every day,\nI'm starting to think it's not so bad after all."
+                "\\N<Manipulated Man>But, if Philis comes to see me like this every day,\nI'm starting to think it's not so bad after all."
               ]
             },
             {
@@ -808,7 +808,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>If you say that, then it's worth coming."
+                "\\CE[79]\\OC[30]\\N<Philis>If you say that, then it's worth coming."
               ]
             },
             {
@@ -821,7 +821,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>From what I can see, it seems quite calm today. At\nthis rate, I believe it won't be long before we\ncan leave here without any problems."
+                "\\CE[79]\\OC[30]\\N<Philis>From what I can see, it seems quite calm today. At\nthis rate, I believe it won't be long before we\ncan leave here without any problems."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -830,7 +830,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Eh?! If that happens, I won't be able to talk\nalone with Phils anymore!"
+                "\\N<Manipulated Man>Eh?! If that happens, I won't be able to talk\nalone with Philis anymore!"
               ]
             },
             {
@@ -843,7 +843,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>If your body recovers, staying cooped up will\nactually make you unhealthy. Besides, I'm mostly\nat the monastery, so we can meet anytime."
+                "\\CE[79]\\OC[30]\\N<Philis>If your body recovers, staying cooped up will\nactually make you unhealthy. Besides, I'm mostly\nat the monastery, so we can meet anytime."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -868,7 +868,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>Sorry, what did you say?"
+                "\\CE[79]\\OC[30]\\N<Philis>Sorry, what did you say?"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -889,7 +889,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I see. Well then, let's start today's treatment,\nshall we? I'll get ready."
+                "\\CE[79]\\OC[30]\\N<Philis>I see. Well then, let's start today's treatment,\nshall we? I'll get ready."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1060,7 +1060,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>Sorry to keep you waiting. Well then, let's\nbegin─────"
+                "\\CE[79]\\OC[30]\\N<Philis>Sorry to keep you waiting. Well then, let's\nbegin─────"
               ]
             },
             {
@@ -1103,7 +1103,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Phils! Actually, there's something I want to talk\nto you about."
+                "\\N<Manipulated Man>Philis! Actually, there's something I want to talk\nto you about."
               ]
             },
             {
@@ -1115,7 +1115,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>Huh, what's wrong?"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>Huh, what's wrong?"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
@@ -1135,7 +1135,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I'm sorry if I made you feel like you had to be\nconsiderate. You don't need to hold back, so\nplease tell me anything."
+                "\\CE[79]\\OC[30]\\N<Philis>I'm sorry if I made you feel like you had to be\nconsiderate. You don't need to hold back, so\nplease tell me anything."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1189,7 +1189,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[83]\\CE[84]\\CE[83]\\OC[30]\\N<Phils>...Um m...─────"
+                "\\CE[79]\\CE[83]\\CE[84]\\CE[83]\\OC[30]\\N<Philis>...Um m...─────"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1197,7 +1197,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>S-Sorry, I'm a little confused...─────"
+                "\\OC[30]\\N<Philis>S-Sorry, I'm a little confused...─────"
               ]
             },
             {
@@ -1229,7 +1229,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>M-Mastu..."]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>M-Mastu..."]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
@@ -1254,7 +1254,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>So, Phils, I have a favor to ask... If someone\nwere to help me, it might be a different kind of\nstimulation than doing it myself and I might be\nable to enjoy it."
+                "\\N<Manipulated Man>So, Philis, I have a favor to ask... If someone\nwere to help me, it might be a different kind of\nstimulation than doing it myself and I might be\nable to enjoy it."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1263,7 +1263,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>So please, I'm begging you! Just with your hand! I\nwant Phils to jerk me off!"
+                "\\N<Manipulated Man>So please, I'm begging you! Just with your hand! I\nwant Philis to jerk me off!"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -1276,7 +1276,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>Um... umm...─────"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>Um... umm...─────"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
@@ -1292,7 +1292,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>I-I'm sorry... I don't really understand much\nabout male anatomy..."
+                "\\OC[30]\\N<Philis>I-I'm sorry... I don't really understand much\nabout male anatomy..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1300,7 +1300,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>Um... if I were to help, would that solve the\nproblem...?"
+                "\\OC[30]\\N<Philis>Um... if I were to help, would that solve the\nproblem...?"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1316,7 +1316,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Besides, I choose who I ask for something like\nthis... I thought that Phils, who would treat me\nwith empathy, could help me with my condition...!"
+                "\\N<Manipulated Man>Besides, I choose who I ask for something like\nthis... I thought that Philis, who would treat me\nwith empathy, could help me with my condition...!"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1325,7 +1325,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>I see... I-I understand. If I can be of help...\nthen... um..."
+                "\\OC[30]\\N<Philis>I see... I-I understand. If I can be of help...\nthen... um..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1364,7 +1364,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>I'm sorry, I came on your face all of a sudden.\nPhils's blowjob felt so good."
+                "\\N<Manipulated Man>I'm sorry, I came on your face all of a sudden.\nPhilis's blowjob felt so good."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1392,7 +1392,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[83]\\OC[30]\\N<Phils>Blowjob? Is that a reproductive organ...?"
+                "\\CE[79]\\CE[83]\\OC[30]\\N<Philis>Blowjob? Is that a reproductive organ...?"
               ]
             },
             {
@@ -1405,7 +1405,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I don't really understand much... but if I was\nable to help you with your problem and\nejaculation, then I'm glad I could be of\nassistance."
+                "\\CE[79]\\OC[30]\\N<Philis>I don't really understand much... but if I was\nable to help you with your problem and\nejaculation, then I'm glad I could be of\nassistance."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -1436,7 +1436,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I see... Is that so? Will you get better soon...?"
+                "\\CE[79]\\OC[30]\\N<Philis>I see... Is that so? Will you get better soon...?"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1457,14 +1457,14 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I-I'll think about it..."
+                "\\CE[79]\\OC[30]\\N<Philis>I-I'll think about it..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Well then, today... Excuse me."]
+              "parameters": ["\\OC[30]\\N<Philis>Well then, today... Excuse me."]
             },
             { "code": 117, "indent": 0, "parameters": [97] },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -1749,7 +1749,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>(As I thought, Phils is definitely a virgin.)"
+                "\\N<Manipulated Man>(As I thought, Philis is definitely a virgin.)"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1989,7 +1989,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>────It's Phils. Can I come in...?"
+                "\\CE[79]\\OC[30]\\N<Philis>────It's Philis. Can I come in...?"
               ]
             },
             {
@@ -2007,7 +2007,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Phils... , please come quickly...!"
+                "\\N<Manipulated Man>Philis... , please come quickly...!"
               ]
             },
             { "code": 122, "indent": 0, "parameters": [78, 78, 0, 0, 99] },
@@ -2211,7 +2211,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>What's wrong!? Are you feeling any pain\nsomewhere!?"
+                "\\CE[79]\\OC[30]\\N<Philis>What's wrong!? Are you feeling any pain\nsomewhere!?"
               ]
             },
             {
@@ -2272,7 +2272,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>Where does it hurt? I'll use healing magic right\naway───"
+                "\\OC[30]\\N<Philis>Where does it hurt? I'll use healing magic right\naway───"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2292,14 +2292,14 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>Eh...─────"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>Eh...─────"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>I'm sorry, Phils...  I've been able to hold back\nbecause you've helped me release, but it seems\nlike I've reached my limit..."
+                "\\N<Manipulated Man>I'm sorry, Philis...  I've been able to hold back\nbecause you've helped me release, but it seems\nlike I've reached my limit..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2313,7 +2313,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>L-Limit...?  What do you mean...─────"
+                "\\CE[79]\\OC[30]\\N<Philis>L-Limit...?  What do you mean...─────"
               ]
             },
             { "code": 242, "indent": 0, "parameters": [1] },
@@ -2323,7 +2323,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>My...desire...─────  Phils, please...let me have\nsex with you...!"
+                "\\N<Manipulated Man>My...desire...─────  Philis, please...let me have\nsex with you...!"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2372,7 +2372,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[83]\\OC[30]\\N<Phils>Eh...─────Eh...!?"
+                "\\CE[79]\\CE[83]\\OC[30]\\N<Philis>Eh...─────Eh...!?"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -2381,7 +2381,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>────Phils... You may not be aware of it, but\nyou're cute, and above all, your breasts are too\nstimulating for me right now...!"
+                "\\N<Manipulated Man>────Philis... You may not be aware of it, but\nyou're cute, and above all, your breasts are too\nstimulating for me right now...!"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2412,14 +2412,14 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>I-I see...─────."]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>I-I see...─────."]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>I'm sorry, even though I was so close, I didn't\nnotice anything... B-because I don't have that\nkind of experience... I didn't understand..."
+                "\\CE[79]\\OC[30]\\N<Philis>I'm sorry, even though I was so close, I didn't\nnotice anything... B-because I don't have that\nkind of experience... I didn't understand..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2472,7 +2472,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Kyaa─────!"]
+              "parameters": ["\\OC[30]\\N<Philis>Kyaa─────!"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
@@ -2503,14 +2503,14 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>\"...\""]
+              "parameters": ["\\OC[30]\\N<Philis>\"...\""]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The Manipulated Man>\"And with you, Phils-chan, right in front of me in\nthis situation... Honestly, I'm holding back so\nmuch that it feels like I could pounce on you at\nany moment...\""
+                "\\N<The Manipulated Man>\"And with you, Philis, right in front of me in\nthis situation... Honestly, I'm holding back so\nmuch that it feels like I could pounce on you at\nany moment...\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2518,7 +2518,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The Manipulated Man>\"Phils-chan... I don't want to force myself on\nyou...!\""
+                "\\N<The Manipulated Man>\"Philis... I don't want to force myself on\nyou...!\""
               ]
             },
             { "code": 235, "indent": 0, "parameters": [60] },
@@ -2545,7 +2545,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Umm... umm...───that...─────"]
+              "parameters": ["\\OC[30]\\N<Philis>Umm... umm...───that...─────"]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2553,7 +2553,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>B-because it's my first time... if you could, um,\nbe gentle with me...if possible..."
+                "\\OC[30]\\N<Philis>B-because it's my first time... if you could, um,\nbe gentle with me...if possible..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2665,7 +2665,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Thanks to you, Phils, the pain has subsided. Thank\nyou so much."
+                "\\N<Manipulated Man>Thanks to you, Philis, the pain has subsided. Thank\nyou so much."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2691,7 +2691,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>────It's not too late to deal with it now, so\ndon't worry...  Besides, I should have told you\nbeforehand too..."
+                "\\CE[79]\\OC[30]\\N<Philis>────It's not too late to deal with it now, so\ndon't worry...  Besides, I should have told you\nbeforehand too..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2700,7 +2700,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Phils, you're really kind.  I'll do my best to\ncontrol myself quickly for your sake...  Please\ntake care of me again if I'm in pain."
+                "\\N<Manipulated Man>Philis, you're really kind.  I'll do my best to\ncontrol myself quickly for your sake...  Please\ntake care of me again if I'm in pain."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2719,7 +2719,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>U-um... Y-yes... Well then, excuse me for today..."
+                "\\CE[79]\\OC[30]\\N<Philis>U-um... Y-yes... Well then, excuse me for today..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -3082,7 +3082,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Male Monk A>W-Why... is Phils with that man...!"
+                "\\N<Male Monk A>W-Why... is Philis with that man...!"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3090,7 +3090,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Male Monk B>And to think that the serious Phils is letting\nsomeone stay for treatment, and moreover, inside\nthe monastery... What on earth happened..."
+                "\\N<Male Monk B>And to think that the serious Philis is letting\nsomeone stay for treatment, and moreover, inside\nthe monastery... What on earth happened..."
               ]
             },
             { "code": 230, "indent": 0, "parameters": [60] },
@@ -3157,7 +3157,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[77]\\C[13]\\OC[31]\\N<Inner Rain>(Phils is also doing her best... I shouldn't just\nbe thinking about naughty things, I need to find\nthe next magical device quickly...!)"
+                "\\CE[77]\\C[13]\\OC[31]\\N<Inner Rain>(Philis is also doing her best... I shouldn't just\nbe thinking about naughty things, I need to find\nthe next magical device quickly...!)"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -3417,7 +3417,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Thank you, Phils! It felt so good today♪"
+                "\\N<Manipulated Man>Thank you, Philis! It felt so good today♪"
               ]
             },
             { "code": 122, "indent": 0, "parameters": [235, 235, 0, 0, 6] },
@@ -3436,7 +3436,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>────Please don't say it so loudly, I can hear\nyou...!"
+                "\\CE[79]\\OC[30]\\N<Philis>────Please don't say it so loudly, I can hear\nyou...!"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3457,7 +3457,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>W-Well then... I'll take my leave for today..."
+                "\\CE[79]\\OC[30]\\N<Philis>W-Well then... I'll take my leave for today..."
               ]
             },
             { "code": 117, "indent": 0, "parameters": [97] },
@@ -4509,7 +4509,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>(Who could it be at this late hour...)"
+                "\\CE[79]\\OC[30]\\N<Philis>(Who could it be at this late hour...)"
               ]
             },
             {
@@ -4627,7 +4627,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[83]\\OC[30]\\N<Phils>Ah... W-What's the matter, ???"
+                "\\CE[79]\\CE[83]\\OC[30]\\N<Philis>Ah... W-What's the matter, ???"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -4636,7 +4636,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>────Phils, I'm sorry for bothering you at this\nhour, but there's something I really need to talk\nto you about."
+                "\\N<Manipulated Man>────Philis, I'm sorry for bothering you at this\nhour, but there's something I really need to talk\nto you about."
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -4650,7 +4650,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>What is it that you want to talk about... ???"
+                "\\CE[79]\\OC[30]\\N<Philis>What is it that you want to talk about... ???"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -4665,7 +4665,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Ah, yes... Please come in."]
+              "parameters": ["\\OC[30]\\N<Philis>Ah, yes... Please come in."]
             },
             { "code": 117, "indent": 0, "parameters": [97] },
             {
@@ -4866,7 +4866,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>Eh... , everyone...!?"]
+              "parameters": ["\\OC[30]\\N<Philis>Eh... , everyone...!?"]
             },
             { "code": 213, "indent": 0, "parameters": [10, 8, false] },
             { "code": 213, "indent": 0, "parameters": [15, 8, true] },
@@ -4876,7 +4876,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Manipulated Man>Actually, you know Phils, they found out that\nwe've been having sex."
+                "\\N<Manipulated Man>Actually, you know Philis, they found out that\nwe've been having sex."
               ]
             },
             { "code": 213, "indent": 0, "parameters": [14, 14, false] },
@@ -4906,7 +4906,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\CE[83]\\OC[30]\\N<Phils>Eh─────!?"]
+              "parameters": ["\\CE[79]\\CE[83]\\OC[30]\\N<Philis>Eh─────!?"]
             },
             {
               "code": 122,
@@ -4929,7 +4929,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Male Monk A>────Phils..., even though the Holy Demon Sect\ndoesn't prohibit sex, we voluntarily lead\nabstinent lives, don't we?"
+                "\\N<Male Monk A>────Philis..., even though the Holy Demon Sect\ndoesn't prohibit sex, we voluntarily lead\nabstinent lives, don't we?"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -4951,7 +4951,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>Um... umm... Well, that's... umm..."
+                "\\CE[79]\\OC[30]\\N<Philis>Um... umm... Well, that's... umm..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -4972,7 +4972,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>...───── ──────"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>...───── ──────"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
@@ -4994,7 +4994,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Male Monk A>─────We didn't come here to blame or preach to\nPhils..."
+                "\\N<Male Monk A>─────We didn't come here to blame or preach to\nPhilis..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -5010,7 +5010,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>Well then... What is it that you want to talk\nabout...?"
+                "\\CE[79]\\OC[30]\\N<Philis>Well then... What is it that you want to talk\nabout...?"
               ]
             },
             { "code": 230, "indent": 0, "parameters": [45] },
@@ -5042,7 +5042,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>Eh...───────!?"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>Eh...───────!?"]
             },
             { "code": 230, "indent": 0, "parameters": [60] },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -5061,7 +5061,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\N<Manipulated Man>Well, certainly, it's pitiful for them to be\nforced to listen to the cute moans of their\nbeloved Phils while gritting their teeth and\nenduring."
+                "\\CE[79]\\N<Manipulated Man>Well, certainly, it's pitiful for them to be\nforced to listen to the cute moans of their\nbeloved Philis while gritting their teeth and\nenduring."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -5084,7 +5084,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>W-We're doing it with all four of us!? S-Something\nlike that..."
+                "\\CE[79]\\OC[30]\\N<Philis>W-We're doing it with all four of us!? S-Something\nlike that..."
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -5114,7 +5114,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Male Monk B>There's no one else but you Phils who can satisfy\nour desires... Of course, it would be ideal to\nhave you one by one, this is a difficult decision."
+                "\\N<Male Monk B>There's no one else but you Philis who can satisfy\nour desires... Of course, it would be ideal to\nhave you one by one, this is a difficult decision."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -5122,7 +5122,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[79]\\OC[30]\\N<Phils>「...────────────"]
+              "parameters": ["\\CE[79]\\OC[30]\\N<Philis>「...────────────"]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
             { "code": 117, "indent": 0, "parameters": [12] },
@@ -5136,7 +5136,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>(─────Certainly... it's my fault that it turned\nout like this... I was swayed by desire...)"
+                "\\CE[79]\\OC[30]\\N<Philis>(─────Certainly... it's my fault that it turned\nout like this... I was swayed by desire...)"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -5150,21 +5150,21 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>(I wasn't really aware of it, but I'm sure my\ndesires have already swelled up... And it's not\nlike I had no interest in sexual things... Rather,\nlately, I feel like I've been yearning for it...)"
+                "\\CE[79]\\OC[30]\\N<Philis>(I wasn't really aware of it, but I'm sure my\ndesires have already swelled up... And it's not\nlike I had no interest in sexual things... Rather,\nlately, I feel like I've been yearning for it...)"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["Phils: (I also feel like that...)"]
+              "parameters": ["Philis: (I also feel like that...)"]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>(─────Rain also... said that in times like this,\nshe deals with it through her body... To satisfy\nthe desires of everyone in town, all by\nherself...)"
+                "\\OC[30]\\N<Philis>(─────Rain also... said that in times like this,\nshe deals with it through her body... To satisfy\nthe desires of everyone in town, all by\nherself...)"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -5178,7 +5178,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[30]\\N<Phils>(─────If that's the case, at least within this\nmonastery, I...────)"
+                "\\CE[79]\\OC[30]\\N<Philis>(─────If that's the case, at least within this\nmonastery, I...────)"
               ]
             },
             { "code": 117, "indent": 0, "parameters": [12] },
@@ -5438,7 +5438,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>For now, I have applied healing and dispelling\nmagic, so I believe their body should be\nrecovering."
+                "\\CE[94]\\OC[30]\\N<Philis>For now, I have applied healing and dispelling\nmagic, so I believe their body should be\nrecovering."
               ]
             },
             {
@@ -5477,14 +5477,14 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>If he starts rampaging, I'll handle it, so Phils,\nplease stay behind me."
+                "\\CE[79]\\OC[31]\\N<Rain>If he starts rampaging, I'll handle it, so Philis,\nplease stay behind me."
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\OC[30]\\N<Phils>I-I understand."]
+              "parameters": ["\\OC[30]\\N<Philis>I-I understand."]
             },
             { "code": 122, "indent": 1, "parameters": [78, 78, 0, 0, 99] },
             { "code": 117, "indent": 1, "parameters": [77] },
@@ -6035,7 +6035,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Something seems... strange!"
+                "\\CE[94]\\OC[30]\\N<Philis>Something seems... strange!"
               ]
             },
             {
@@ -6277,7 +6277,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\OC[30]\\N<Phils>No... please don't come any closer!"
+                "\\OC[30]\\N<Philis>No... please don't come any closer!"
               ]
             },
             { "code": 122, "indent": 1, "parameters": [78, 78, 0, 0, 99] },
@@ -6455,7 +6455,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Yes..., it seems so..."]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Yes..., it seems so..."]
             },
             { "code": 117, "indent": 1, "parameters": [80] },
             { "code": 230, "indent": 1, "parameters": [30] },
@@ -6573,7 +6573,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>「...──────────"]
+              "parameters": ["\\OC[30]\\N<Philis>「...──────────"]
             },
             { "code": 230, "indent": 0, "parameters": [15] },
             {
@@ -6591,7 +6591,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Phils... Your face is all red, isn't it?"
+                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Philis... Your face is all red, isn't it?"
               ]
             },
             {
@@ -6609,7 +6609,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\CE[96]\\OC[30]\\N<Phils>─────Eh, I-I see...? There's nothing wrong\nthough..."
+                "\\CE[94]\\CE[96]\\OC[30]\\N<Philis>─────Eh, I-I see...? There's nothing wrong\nthough..."
               ]
             },
             {
@@ -6734,7 +6734,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[30]\\N<Phils>「...──────────"]
+              "parameters": ["\\OC[30]\\N<Philis>「...──────────"]
             },
             { "code": 230, "indent": 0, "parameters": [15] },
             {
@@ -6752,7 +6752,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Phils... Your face is all red, isn't it?"
+                "\\CE[79]\\CE[78]\\OC[31]\\N<Rain>Hey, Philis... Your face is all red, isn't it?"
               ]
             },
             {
@@ -6765,7 +6765,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\CE[96]\\OC[30]\\N<Phils>Eh... Is that so? Well, there's nothing wrong with\nme..."
+                "\\CE[94]\\CE[96]\\OC[30]\\N<Philis>Eh... Is that so? Well, there's nothing wrong with\nme..."
               ]
             },
             {
@@ -6865,7 +6865,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Phils>Rain... um, I'm having trouble with where to\nlook... so if you could wear clothing with a\nlittle less exposure, I would appreciate it..."
+                "\\N<Philis>Rain... um, I'm having trouble with where to\nlook... so if you could wear clothing with a\nlittle less exposure, I would appreciate it..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -7450,7 +7450,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\EMP Phils... you look cute today..."]
+              "parameters": ["\\EMP Philis... you look cute today..."]
             },
             { "code": 0, "indent": 1, "parameters": [] },
             { "code": 412, "indent": 0, "parameters": [] },
@@ -7459,7 +7459,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\EMP Phils... damn, I'm so jealous...!"]
+              "parameters": ["\\EMP Philis... damn, I'm so jealous...!"]
             },
             { "code": 0, "indent": 1, "parameters": [] },
             { "code": 412, "indent": 0, "parameters": [] },
@@ -7805,7 +7805,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\EMP I wonder if Phils would take care of me if I\ngot injured..."
+                "\\EMP I wonder if Philis would take care of me if I\ngot injured..."
               ]
             },
             { "code": 0, "indent": 1, "parameters": [""] },
@@ -7828,7 +7828,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\EMP───Haa... Phils... ♥"]
+              "parameters": ["\\EMP───Haa... Philis... ♥"]
             },
             { "code": 0, "indent": 1, "parameters": [] },
             { "code": 412, "indent": 0, "parameters": [] },

--- a/www/data/Map080.json
+++ b/www/data/Map080.json
@@ -5113,7 +5113,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[31]\\N<Rain>They're unconscious... I'll leave this person to\nPhils."
+                "\\OC[31]\\N<Rain>They're unconscious... I'll leave this person to\nPhilis."
               ]
             },
             { "code": 221, "indent": 0, "parameters": [] },

--- a/www/data/Map091.json
+++ b/www/data/Map091.json
@@ -3489,7 +3489,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The Begging Man>\"But, it has to be her... I really want Meryl-\nchan...! Please, can't you do something...!\""
+                "\\N<The Begging Man>\"But, it has to be her... I really want Meryl\n...! Please, can't you do something...!\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3675,7 +3675,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Meryl-chan! You remember me...!\""
+                "\\N<The man who was a neighbor at the inn>\"Meryl! You remember me...!\""
               ]
             },
             { "code": 213, "indent": 0, "parameters": [29, 4, false] },
@@ -3719,7 +3719,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\n<Brothel Receptionist>\"I'm sorry, Meryl-chan. I'll have this man leave\nnow, so don't worry and go back to your room.\""
+                "\\n<Brothel Receptionist>\"I'm sorry, Meryl. I'll have this man leave\nnow, so don't worry and go back to your room.\""
               ]
             },
             { "code": 230, "indent": 0, "parameters": [15] },
@@ -3791,7 +3791,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Of course! Thank you, Meryl-chan...!\""
+                "\\N<The man who was a neighbor at the inn>\"Of course! Thank you, Meryl...!\""
               ]
             },
             { "code": 230, "indent": 0, "parameters": [15] },
@@ -3800,7 +3800,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\n<Brothel Receptionist>\"────Well, if Meryl-chan says so, I guess it's\nokay this time... But are you really alright? Your\nface looks a bit red...\""
+                "\\n<Brothel Receptionist>\"────Well, if Meryl says so, I guess it's\nokay this time... But are you really alright? Your\nface looks a bit red...\""
               ]
             },
             {

--- a/www/data/Map093.json
+++ b/www/data/Map093.json
@@ -821,7 +821,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\n<Meryl>\"I'll advance the analysis of the four fragments\nas much as possible before we depart, so please\nmake sure you get plenty of rest and be prepared,\nRain-san!\""
+                "\\n<Meryl>\"I'll advance the analysis of the four fragments\nas much as possible before we depart, so please\nmake sure you get plenty of rest and be prepared,\nRain!\""
               ]
             },
             { "code": 0, "indent": 1, "parameters": [] },
@@ -908,7 +908,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[77]\\OC[31]\\N<Rain>\"Meryl-san, you don't look so well. Are you\nfeeling okay?\""
+                "\\CE[77]\\OC[31]\\N<Rain>\"Meryl, you don't look so well. Are you\nfeeling okay?\""
               ]
             },
             { "code": 122, "indent": 0, "parameters": [77, 77, 0, 0, 8] },
@@ -1076,7 +1076,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[79]\\OC[25]\\N<Meryl>\"I'm so tired... I ended up not eating or drinking\nagain... Rain-san is going to scold me.\""
+                "\\CE[79]\\OC[25]\\N<Meryl>\"I'm so tired... I ended up not eating or drinking\nagain... Rain is going to scold me.\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -1128,7 +1128,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\"Please! I really need it to be Meryl-chan!!\""]
+              "parameters": ["\"Please! I really need it to be Meryl!!\""]
             },
             { "code": 213, "indent": 0, "parameters": [-1, 1, true] },
             { "code": 230, "indent": 0, "parameters": [30] },
@@ -1908,7 +1908,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Phew... Alright, everything's ready...! I can't\nhold back anymore, Meryl-chan...!!\""
+                "\\N<The man who was a neighbor at the inn>\"Phew... Alright, everything's ready...! I can't\nhold back anymore, Meryl...!!\""
               ]
             },
             { "code": 122, "indent": 0, "parameters": [78, 78, 0, 0, 98] },

--- a/www/data/Map098.json
+++ b/www/data/Map098.json
@@ -835,7 +835,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\EMP My my, you're quite sloppy, Holy Knight-\nsama. Shall I lend you a shoulder? Hahaha!"
+                "\\EMP My my, you're quite sloppy, Holy Knight\n. Shall I lend you a shoulder? Hahaha!"
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },
@@ -2969,7 +2969,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Rain!"]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Rain!"]
             },
             { "code": 230, "indent": 0, "parameters": [30] },
             {
@@ -3005,7 +3005,7 @@
             {
               "code": 401,
               "indent": 0,
-              "parameters": ["\\OC[31]\\N<Rain>Phils, Caldo!? Why...───"]
+              "parameters": ["\\OC[31]\\N<Rain>Philis, Caldo!? Why...───"]
             },
             {
               "code": 122,
@@ -3017,7 +3017,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Someone named Meryl gave me this location, we\nfollowed after your magical power!"
+                "\\CE[94]\\OC[30]\\N<Philis>Someone named Meryl gave me this location, we\nfollowed after your magical power!"
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -3429,7 +3429,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\OC[30]\\N<Phils>I can sense a strong presence of dark magic ahead,\nso please be careful!  May the blessings of the\nHoly Demon be with you..."
+                "\\OC[30]\\N<Philis>I can sense a strong presence of dark magic ahead,\nso please be careful!  May the blessings of the\nHoly Demon be with you..."
               ]
             },
             { "code": 0, "indent": 0, "parameters": [""] },

--- a/www/data/Map105.json
+++ b/www/data/Map105.json
@@ -1429,7 +1429,7 @@
             {
               "code": 401,
               "indent": 1,
-              "parameters": ["\\OC[30]\\N<Phils>Raaaiin!"]
+              "parameters": ["\\OC[30]\\N<Philis>Raaaiin!"]
             },
             { "code": 117, "indent": 1, "parameters": [97] },
             { "code": 213, "indent": 1, "parameters": [-1, 1, false] },
@@ -1674,7 +1674,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[93]\\OC[30]\\N<Phils>Amazing! So, with this, all the evil magic will\ndisappear, right?"
+                "\\CE[93]\\OC[30]\\N<Philis>Amazing! So, with this, all the evil magic will\ndisappear, right?"
               ]
             },
             { "code": 230, "indent": 1, "parameters": [60] },
@@ -1800,7 +1800,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[79]\\CE[94]\\OC[30]\\N<Phils>Th-this person is...───!?"
+                "\\CE[79]\\CE[94]\\OC[30]\\N<Philis>Th-this person is...───!?"
               ]
             },
             { "code": 230, "indent": 1, "parameters": [30] },
@@ -2302,7 +2302,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>We must also call Father Frist and have a\nconversation..."
+                "\\CE[94]\\OC[30]\\N<Philis>We must also call Father Frist and have a\nconversation..."
               ]
             },
             {

--- a/www/data/Map106.json
+++ b/www/data/Map106.json
@@ -1153,7 +1153,7 @@
             {
               "code": 401,
               "indent": 2,
-              "parameters": ["\\CE[94]\\OC[30]\\N<Phils>Rain, from us too..."]
+              "parameters": ["\\CE[94]\\OC[30]\\N<Philis>Rain, from us too..."]
             },
             {
               "code": 205,
@@ -1198,7 +1198,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\N<Frist>I poured as much of my and Sister Phils'\nprotective power into it as possible. Just like\nwhat I embedded in the badge before, it can only\nbe used once, but I hope it will be somewhat\nhelpful."
+                "\\CE[94]\\N<Frist>I poured as much of my and Sister Philis'\nprotective power into it as possible. Just like\nwhat I embedded in the badge before, it can only\nbe used once, but I hope it will be somewhat\nhelpful."
               ]
             },
             { "code": 0, "indent": 2, "parameters": [""] },
@@ -1212,7 +1212,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[79]\\OC[31]\\N<Rain>Thank you, Phils and Frist..."
+                "\\CE[79]\\OC[31]\\N<Rain>Thank you, Philis and Frist..."
               ]
             },
             { "code": 126, "indent": 2, "parameters": [39, 0, 0, 1] },
@@ -1307,7 +1307,7 @@
               "code": 401,
               "indent": 2,
               "parameters": [
-                "\\CE[94]\\OC[30]\\N<Phils>Please take care of yourself...!"
+                "\\CE[94]\\OC[30]\\N<Philis>Please take care of yourself...!"
               ]
             },
             { "code": 230, "indent": 2, "parameters": [30] },

--- a/www/data/Map122.json
+++ b/www/data/Map122.json
@@ -10595,7 +10595,7 @@
             {
               "code": 122,
               "indent": 1,
-              "parameters": [327, 327, 0, 4, "\"Phils Event 1\""]
+              "parameters": [327, 327, 0, 4, "\"Philis Event 1\""]
             },
             { "code": 122, "indent": 1, "parameters": [326, 326, 0, 0, 277] },
             { "code": 122, "indent": 1, "parameters": [71, 71, 0, 0, 169] },
@@ -10829,7 +10829,7 @@
             {
               "code": 122,
               "indent": 1,
-              "parameters": [327, 327, 0, 4, "\"Phils Event 2\""]
+              "parameters": [327, 327, 0, 4, "\"Philis Event 2\""]
             },
             { "code": 122, "indent": 1, "parameters": [326, 326, 0, 0, 278] },
             { "code": 122, "indent": 1, "parameters": [71, 71, 0, 0, 169] },
@@ -10844,7 +10844,7 @@
                 327,
                 0,
                 4,
-                "\"[Hint of Liberation] Go to the monastery after 2 days from\\nPhils Event 1\""
+                "\"[Hint of Liberation] Go to the monastery after 2 days from\\nPhilis Event 1\""
               ]
             },
             { "code": 0, "indent": 2, "parameters": [] },
@@ -10975,7 +10975,7 @@
             {
               "code": 122,
               "indent": 1,
-              "parameters": [327, 327, 0, 4, "\"Phils Event 3\""]
+              "parameters": [327, 327, 0, 4, "\"Philis Event 3\""]
             },
             { "code": 122, "indent": 1, "parameters": [326, 326, 0, 0, 279] },
             { "code": 122, "indent": 1, "parameters": [71, 71, 0, 0, 169] },

--- a/www/data/Map126.json
+++ b/www/data/Map126.json
@@ -2520,7 +2520,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\CE[79]\\N<Item Shop Owner>\"That's the spirit, knight-sama! You're a\nlifesaver!\""
+                "\\CE[79]\\N<Item Shop Owner>\"That's the spirit, Lady Knight! You're a\nlifesaver!\""
               ]
             },
             { "code": 101, "indent": 6, "parameters": ["", 0, 0, 2] },
@@ -2668,7 +2668,7 @@
               "code": 401,
               "indent": 6,
               "parameters": [
-                "\\N<Item Shop Owner>\"The bikini armor beauty from the rumors, Rain-\nsan!\""
+                "\\N<Item Shop Owner>\"The bikini armor beauty from the rumors, Rain!\""
               ]
             },
             {

--- a/www/data/Map131.json
+++ b/www/data/Map131.json
@@ -1265,7 +1265,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<Checkpoint Guard>I am honored to be able to assist you, Holy\nKnight-sama."
+                "\\N<Checkpoint Guard>I am honored to be able to assist you, Holy\nKnight."
               ]
             },
             { "code": 230, "indent": 0, "parameters": [30] },

--- a/www/data/Map135.json
+++ b/www/data/Map135.json
@@ -2180,7 +2180,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\N<Demure Lady>\"Ah... K, knight-san... Good afternoon...\""
+                "\\N<Demure Lady>\"Ah... K, Miss Knight... Good afternoon...\""
               ]
             },
             { "code": 230, "indent": 4, "parameters": [15] },
@@ -2321,7 +2321,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\N<Demure Lady>\"Ah, um... Actually, there's something I'd like to\nask of you, knight-san...\""
+                "\\N<Demure Lady>\"Ah, um... Actually, there's something I'd like to\nask of you, Miss Knight...\""
               ]
             },
             {
@@ -2529,7 +2529,7 @@
               "code": 401,
               "indent": 4,
               "parameters": [
-                "\\CE[79]\\N<Demure Madame>\"─────Thank you so much... I couldn't ask this of\nanyone but you, knight-san...\""
+                "\\CE[79]\\N<Demure Madame>\"─────Thank you so much... I couldn't ask this of\nanyone but you, Miss Knight...\""
               ]
             },
             { "code": 101, "indent": 4, "parameters": ["", 0, 0, 2] },
@@ -2657,7 +2657,7 @@
               "code": 401,
               "indent": 5,
               "parameters": [
-                "\\CE[77]\\N<Demure Lady>\"Ah... K, knight-san... Thank you for the other\nday...\""
+                "\\CE[77]\\N<Demure Lady>\"Ah... K, Miss Knight... Thank you for the other\nday...\""
               ]
             },
             {

--- a/www/data/Map171.json
+++ b/www/data/Map171.json
@@ -6581,7 +6581,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\N<Casino Staff>\"─────So, the stakes are the same as last time,\nwith \\N[18]-sama wagering 1200 chips\\C[0], and\nRain-sama wagering the right to become\n\\N[18]-sama's woman for one night\\C[0], is that\ncorrect?\""
+                "\\N<Casino Staff>\"─────So, the stakes are the same as last time,\nwith Sir\\N[18] wagering 1200 chips\\C[0], and\nLady Rain wagering the right to become Sir\n\\N[18]'s woman for one night\\C[0], is that\ncorrect?\""
               ]
             },
             { "code": 230, "indent": 1, "parameters": [30] },
@@ -6658,7 +6658,7 @@
               "code": 401,
               "indent": 1,
               "parameters": [
-                "\\N<Casino Staff>\"Understood. \\N[18]-sama will be selecting the\nopposite player then.\""
+                "\\N<Casino Staff>\"Understood. Sir \\N[18] will be selecting the\nopposite player then.\""
               ]
             },
             { "code": 101, "indent": 1, "parameters": ["", 0, 0, 2] },

--- a/www/data/Map172.json
+++ b/www/data/Map172.json
@@ -1969,7 +1969,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Good morning, Meryl-chan.\""
+                "\\N<The man who was a neighbor at the inn>\"Good morning, Meryl.\""
               ]
             },
             {
@@ -1996,7 +1996,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"I'm sorry, Meryl-chan, I just had to see you...\nIt was a bit rough, but I put you to sleep and\nbrought you here.\""
+                "\\N<The man who was a neighbor at the inn>\"I'm sorry, Meryl, I just had to see you...\nIt was a bit rough, but I put you to sleep and\nbrought you here.\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2039,7 +2039,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Besides, Meryl-chan feels the same way, right!?\nWe loved each other so much, and you came so hard!\nI thought for sure your womb must be aching by\nnow...!\""
+                "\\N<The man who was a neighbor at the inn>\"Besides, Meryl feels the same way, right!?\nWe loved each other so much, and you came so hard!\nI thought for sure your womb must be aching by\nnow...!\""
               ]
             },
             {
@@ -2060,7 +2060,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"Meryl-chan has to sleep with many other men\nbecause of her job, so you've probably forgotten\nthe taste of my cock. That's why today, I'll make\nyou remember with a special method.\""
+                "\\N<The man who was a neighbor at the inn>\"Meryl has to sleep with many other men\nbecause of her job, so you've probably forgotten\nthe taste of my cock. That's why today, I'll make\nyou remember with a special method.\""
               ]
             },
             { "code": 101, "indent": 0, "parameters": ["", 0, 0, 2] },
@@ -2068,7 +2068,7 @@
               "code": 401,
               "indent": 0,
               "parameters": [
-                "\\N<The man who was a neighbor at the inn>\"You see, since then I've worked hard and trained\nso that Meryl-chan can feel even better. That's\nwhy it's a bit tight and uncomfortable, but please\nbear with it a little longer.\""
+                "\\N<The man who was a neighbor at the inn>\"You see, since then I've worked hard and trained\nso that Meryl can feel even better. That's\nwhy it's a bit tight and uncomfortable, but please\nbear with it a little longer.\""
               ]
             },
             {


### PR DESCRIPTION
Always thought Phils was a weird name, Philis makes way more sense.
- changed Phils to Philis

Deleted honorifics in my previous pull request, so deleted the ones that reappeared after update 2.0
- deleted -chan with no substitutions except for the occurrences of onee-chan and onii-chan
- deleted -san with some substitution based on context
- deleted -sama with some substitutions based on context

Chief sounds like a weird military rank
- changed references of chief caldo to captain caldo